### PR TITLE
Resolve merge conflict in carousel API

### DIFF
--- a/pages/api/getCarousel.ts
+++ b/pages/api/getCarousel.ts
@@ -1,5 +1,3 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 import { query } from "@/lib/db";
 
 export default async function handler(req, res) {
@@ -7,42 +5,11 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: `Method ${req.method} not allowed` });
   }
 
-  try {
-    const result = await query("SELECT * FROM home_carousel");
-    res.status(200).json(result.rows);
-  } catch (error) {
-    console.error("Error fetching images", error);
-    res.status(500).json({ error: "Error fetching images" });
-  }
-}
-=======
-// import { query } from "@/lib/db";
-=======
-import { query } from "@/lib/db";
->>>>>>> fca4660 (cambiando a sql)
-
-export default async function handler(req, res) {
-  if (req.method !== "GET") {
-    return res.status(405).json({ error: `Method ${req.method} not allowed` });
-  }
-
-<<<<<<< HEAD
-//   try {
-//     const result = await query("SELECT * FROM home_carousel");
-//     res.status(200).json(result.rows);
-//   } catch (error) {
-//     console.error("Error fetching images", error);
-//     res.status(500).json({ error: "Error fetching images" });
-//   }
-// }
->>>>>>> 7f8deaf (Descripción de los cambios realizados)
-=======
   try {
     const result = await query("SELECT * FROM carrousel");
-    res.status(200).json(result.rows);
+    res.status(200).json(result);
   } catch (error) {
     console.error("Error fetching images", error);
     res.status(500).json({ error: "Error fetching images" });
   }
 }
->>>>>>> fca4660 (cambiando a sql)


### PR DESCRIPTION
## Summary
- resolve merge conflict markers in `pages/api/getCarousel.ts`
- ensure the carousel endpoint queries the new `carrousel` table and returns the query result

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cdd24bb814832c83027c05aaef8461