### PR TITLE
Replace Material UI with Tailwind components

### DIFF
--- a/app/donations/page.tsx
+++ b/app/donations/page.tsx
@@ -1,9 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
 import { loadStripe } from "@stripe/stripe-js";
-import Box from "@mui/material/Box";
-import FormControl from "@mui/material/FormControl";
-import NativeSelect from "@mui/material/NativeSelect";
 import BtnHome from "@components/btnHome";
 
 const stripePromise = loadStripe(
@@ -88,25 +85,25 @@ const DonateForm = () => {
       className="flex flex-col justify-center items-center p-4 bg-gray-200 h-screen rounded-md shadow-md"
     >
       
-      <h2 className="text-2xl text-center font-bold mb-4">Donar</h2>
-      <Box sx={{ minWidth: 265, mb: 3 }}>
-        <FormControl fullWidth>
-          <NativeSelect
-            value={paymentMethod}
-            onChange={(e) => setPaymentMethod(e.target.value)}
-            inputProps={{
-              name: "paymentMethod",
-              id: "uncontrolled-native",
-            }}
-          >
-            <option value="1" disabled>
-              Seleccione un método de pago
-            </option>
-            <option value="stripe">Stripe</option>
-            <option value="tropipay">TropiPay</option>
-          </NativeSelect>
-        </FormControl>
-      </Box>
+      <h2 className="mb-4 text-center text-2xl font-bold">Donar</h2>
+      <div className="mb-3 w-[265px]">
+        <label htmlFor="paymentMethod" className="sr-only">
+          Método de pago
+        </label>
+        <select
+          id="paymentMethod"
+          name="paymentMethod"
+          value={paymentMethod}
+          onChange={(e) => setPaymentMethod(e.target.value)}
+          className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+        >
+          <option value="1" disabled>
+            Seleccione un método de pago
+          </option>
+          <option value="stripe">Stripe</option>
+          <option value="tropipay">TropiPay</option>
+        </select>
+      </div>
       {paymentMethod === "stripe" && (
         <>
           <div className="mb-4">

--- a/app/secret/page.tsx
+++ b/app/secret/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import LoginIcon from "@mui/icons-material/Login";
-import { TextField, InputAdornment, Button } from "@mui/material";
-import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
-import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import {
+  ArrowRightOnRectangleIcon,
+  LockClosedIcon,
+  UserIcon,
+} from "@components/icons";
 import BtnHome from "@components/btnHome";
 
 const AdminLogin = () => {
@@ -46,39 +47,31 @@ const AdminLogin = () => {
       <label className="text-3xl text-center text-slate-700 my-14">
         Bienvenido al Sistema de Administración
       </label>
-      <BtnHome/>
+      <BtnHome />
       <div className="flex flex-col text-center items-center border w-96 drop-shadow-lg bg-white">
         <div className="w-72 my-8">
           <label className="text-xl">Administrador</label>
           <div className="flex flex-col w-full mt-8 text-left gap-y-8">
-            <TextField
-              id="userName"
-              onChange={(e) => setUser(e.target.value)}
-              type="text"
-              placeholder="Usuario"
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <PersonOutlineIcon />
-                  </InputAdornment>
-                ),
-              }}
-              className="rounded-sm p-1 bg-slate-200"
-            />
-            <TextField
-              id="pass"
-              onChange={(e) => setPass(e.target.value)}
-              type="password"
-              placeholder="Contraseña"
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <LockOutlinedIcon />
-                  </InputAdornment>
-                ),
-              }}
-              className="rounded-sm p-1 bg-slate-200"
-            />
+            <label className="relative flex items-center">
+              <UserIcon className="absolute left-3 h-5 w-5 text-slate-500" />
+              <input
+                id="userName"
+                onChange={(e) => setUser(e.target.value)}
+                type="text"
+                placeholder="Usuario"
+                className="w-full rounded-sm border border-slate-300 bg-slate-200 py-2 pl-10 pr-3 text-sm text-slate-700 outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500"
+              />
+            </label>
+            <label className="relative flex items-center">
+              <LockClosedIcon className="absolute left-3 h-5 w-5 text-slate-500" />
+              <input
+                id="pass"
+                onChange={(e) => setPass(e.target.value)}
+                type="password"
+                placeholder="Contraseña"
+                className="w-full rounded-sm border border-slate-300 bg-slate-200 py-2 pl-10 pr-3 text-sm text-slate-700 outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500"
+              />
+            </label>
           </div>
           <div className="error-container">
             <p
@@ -88,14 +81,13 @@ const AdminLogin = () => {
             </p>
           </div>
           <div className="flex flex-row justify-center mt-5 gap-6">
-            <Button
+            <button
               type="submit"
-              variant="contained"
-              startIcon={<LoginIcon />}
-              className="bg-green-600 hover:bg-green-700 text-white w-full"
+              className="flex w-full items-center justify-center gap-2 rounded-md bg-green-600 py-2 text-sm font-semibold uppercase tracking-wide text-white transition hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
             >
-              ENTRAR
-            </Button>
+              <ArrowRightOnRectangleIcon className="h-5 w-5" />
+              Entrar
+            </button>
           </div>
         </div>
       </div>

--- a/components/adminPage/home-carousel/homeCarousel.tsx
+++ b/components/adminPage/home-carousel/homeCarousel.tsx
@@ -1,9 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
-import IconButton from "@mui/material/IconButton";
-import Button from "@mui/material/Button";
-import PublishRoundedIcon from "@mui/icons-material/PublishRounded";
-import DeleteIcon from "@mui/icons-material/Delete";
+import { ArrowUpTrayIcon, TrashIcon } from "@components/icons";
 import ImageInput from "./imageInput";
 import ImagePreview from "./imagePreview";
 import ProgressBar from "./progressBar";
@@ -30,39 +27,32 @@ const HomeCarousel = () => {
   return (
     <div className="flex flex-col justify-center items-center w-full relative">
       <h1 className="font-serif text-3xl py-5 text-amber-800">
-      Imágenes en el Carrusel
-        </h1>
+        Imágenes en el Carrusel
+      </h1>
       <ProgressBar progress={uploadProgress} uploading={uploading} />
       <ImageInput onFilesSelected={(files) => handleFilesSelected(files, selectedFiles, setSelectedFiles, setError)} />
       <ImagePreview
         selectedFiles={selectedFiles}
         onDelete={(index) => handleDeleteSelected(index, setSelectedFiles)}
       />
-      <Button
-        onClick={() => handleUpload(selectedFiles, setUploading, setUploadProgress, setSelectedFiles, fetchImages, setUploadedImages)}
+      <button
+        type="button"
+        onClick={() =>
+          handleUpload(
+            selectedFiles,
+            setUploading,
+            setUploadProgress,
+            setSelectedFiles,
+            fetchImages,
+            setUploadedImages
+          )
+        }
         disabled={selectedFiles.length === 0 || uploading}
-        variant="contained"
-        component="span"
-        startIcon={<PublishRoundedIcon />}
-        sx={{
-          display: 'flex',
-          flexDirection: 'row',
-          justifyContent: 'center',
-          gap: 1,
-          backgroundColor: selectedFiles.length === 0 || uploading ? 'gray' : 'green',
-          cursor: selectedFiles.length === 0 || uploading ? 'not-allowed' : 'pointer',
-          color: 'white',
-          '&:hover': {
-            backgroundColor: selectedFiles.length === 0 || uploading ? 'gray' : 'darkgreen',
-          },
-          textTransform: 'none', // prevent all caps
-          fontSize: '16px',
-          padding: '8px 16px',
-          marginTop: '24px'
-        }}
+        className="mt-6 flex items-center gap-2 rounded-md bg-green-600 px-4 py-2 text-white transition hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-gray-400"
       >
+        <ArrowUpTrayIcon className="h-5 w-5" />
         Subir imágenes
-      </Button>
+      </button>
       <ErrorMessage error={error} />
       <h1 className="font-serif text-2xl py-5 mt-8">Imágenes en la base de datos Carrusel</h1>
       <div className="bg-gray-200 mt-4 mx-10 mb-10 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
@@ -74,13 +64,14 @@ const HomeCarousel = () => {
                 alt={`uploaded-${index}`}
                 className="w-full h-full object-cover rounded"
               />
-              <IconButton
-                aria-label="delete"
-                className="absolute top-0 right-0"
+              <button
+                type="button"
+                aria-label="Eliminar imagen"
+                className="absolute right-2 top-2 rounded-full bg-white/90 p-1 text-red-600 shadow transition hover:bg-red-100"
                 onClick={() => handleDeleteUploaded(image.id, setUploadedImages)}
               >
-                <DeleteIcon style={{ color: "red" }} />
-              </IconButton>
+                <TrashIcon className="h-5 w-5" />
+              </button>
             </div>
           </div>
         ))}

--- a/components/adminPage/home-carousel/imageInput.tsx
+++ b/components/adminPage/home-carousel/imageInput.tsx
@@ -1,36 +1,35 @@
-import React from "react";
-import AddIcon from "@mui/icons-material/Add";
-import { styled } from "@mui/material/styles";
-import Button from "@mui/material/Button";
-
-const HiddenInput = styled("input")({
-  display: "none",
-});
+import React, { useRef } from "react";
+import { PlusIcon } from "@components/icons";
 
 const ImageInput = ({ onFilesSelected }) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
   const handleChange = (event) => {
     onFilesSelected(event.target.files);
   };
 
+  const handleClick = () => {
+    inputRef.current?.click();
+  };
+
   return (
     <div className="flex flex-col items-center">
-      <label htmlFor="image-upload">
-        <HiddenInput
-          id="image-upload"
-          type="file"
-          accept="image/*"
-          multiple
-          onChange={handleChange}
-        />
-        <Button
-          variant="contained"
-          component="span"
-          startIcon={<AddIcon />}
-          className="bg-blue-600 hover:bg-blue-900 text-white"
-        >
-          Seleccionar imágenes
-        </Button>
-      </label>
+      <input
+        ref={inputRef}
+        id="image-upload"
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={handleChange}
+        className="hidden"
+      />
+      <button
+        type="button"
+        onClick={handleClick}
+        className="flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      >
+        <PlusIcon className="h-5 w-5" /> Seleccionar imágenes
+      </button>
     </div>
   );
 };

--- a/components/adminPage/home-carousel/imagePreview.tsx
+++ b/components/adminPage/home-carousel/imagePreview.tsx
@@ -1,40 +1,43 @@
 import React from "react";
-import IconButton from "@mui/material/IconButton";
-import DeleteIcon from "@mui/icons-material/Delete";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import { ChevronLeftIcon, ChevronRightIcon, TrashIcon } from "@components/icons";
 
 const ImagePreview = ({ selectedFiles, onDelete, moveImage }) => (
-  <div className="bg-green-100 mt-4 mx-10 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+  <div className="bg-green-100 mt-4 mx-10 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
     {selectedFiles.map((file, index) => (
       <div key={index} className="relative h-52">
         <div className="h-40">
           <img
             src={URL.createObjectURL(file)}
             alt={`preview-${index}`}
-            className="w-full h-full object-cover rounded"
+            className="h-full w-full rounded object-cover"
           />
-          <div className="flex justify-between mt-2">
-            <IconButton
-              aria-label="move-left"
+          <div className="mt-2 flex items-center justify-between">
+            <button
+              type="button"
+              aria-label="Mover a la izquierda"
               onClick={() => moveImage(index, -1)}
               disabled={index === 0}
+              className="rounded-md p-1 text-gray-700 transition hover:bg-gray-200 disabled:cursor-not-allowed disabled:text-gray-400"
             >
-              <ArrowBackIcon style={{ color: index === 0 ? "gray" : "black" }} />
-            </IconButton>
-            <IconButton
-              aria-label="delete"
+              <ChevronLeftIcon className="h-5 w-5" />
+            </button>
+            <button
+              type="button"
+              aria-label="Eliminar imagen"
               onClick={() => onDelete(index)}
+              className="rounded-md p-1 text-red-600 transition hover:bg-red-100"
             >
-              <DeleteIcon style={{ color: "red" }} />
-            </IconButton>
-            <IconButton
-              aria-label="move-right"
+              <TrashIcon className="h-5 w-5" />
+            </button>
+            <button
+              type="button"
+              aria-label="Mover a la derecha"
               onClick={() => moveImage(index, 1)}
               disabled={index === selectedFiles.length - 1}
+              className="rounded-md p-1 text-gray-700 transition hover:bg-gray-200 disabled:cursor-not-allowed disabled:text-gray-400"
             >
-              <ArrowForwardIcon style={{ color: index === selectedFiles.length - 1 ? "gray" : "black" }} />
-            </IconButton>
+              <ChevronRightIcon className="h-5 w-5" />
+            </button>
           </div>
         </div>
       </div>

--- a/components/adminPage/home-carousel/progressBar.tsx
+++ b/components/adminPage/home-carousel/progressBar.tsx
@@ -1,45 +1,24 @@
 import React from "react";
-import LinearProgress from "@mui/material/LinearProgress";
-import Box from "@mui/material/Box";
-import { styled } from "@mui/material/styles";
 
-const CustomLinearProgress = styled(LinearProgress)({
-  height: 10, // Ajusta la altura de la barra de progreso
-  borderRadius: 5,
-  backgroundColor: "#ffffff", // Color de fondo de la barra de progreso
-  "& .MuiLinearProgress-bar": {
-    borderRadius: 5,
-    backgroundColor: "#68d391", // Color de la barra de progreso
-  },
-});
+const ProgressBar = ({ progress, uploading }) => {
+  if (!uploading) {
+    return null;
+  }
 
-const ProgressBar = ({ progress, uploading }) => (
-  uploading ? (
-    <Box
-      sx={{
-        position: "fixed",
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        backgroundColor: "rgba(255, 255, 255, 0.75)",
-        zIndex: 1500,
-        backdropFilter: "blur(5px)",
-      }}
-    >
-      <CustomLinearProgress
-        variant="determinate"
-        value={progress}
-        sx={{
-          width: "80%",
-          height: 10,
-        }}
-      />
-    </Box>
-  ) : null
-);
+  const safeProgress = Math.min(Math.max(progress, 0), 100);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/75 backdrop-blur-sm">
+      <div className="w-4/5 max-w-md rounded-full bg-white p-2 shadow-lg">
+        <div className="h-3 w-full rounded-full bg-gray-200">
+          <div
+            className="h-full rounded-full bg-green-400 transition-all duration-200"
+            style={{ width: `${safeProgress}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export default ProgressBar;

--- a/components/adminPage/workers/workers.tsx
+++ b/components/adminPage/workers/workers.tsx
@@ -1,34 +1,8 @@
 "use client";
-import React, { useState, useEffect } from "react";
-import Button from "@mui/material/Button";
-import AddIcon from "@mui/icons-material/Add";
-import Modal from "@mui/material/Modal";
-import TextField from "@mui/material/TextField";
-import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
-import CloseIcon from "@mui/icons-material/Close";
-import { styled } from "@mui/material/styles";
+import React, { useState, useEffect, useRef } from "react";
+import { PlusIcon, XMarkIcon } from "@components/icons";
 import axios from "axios";
 import ProgressBar from "@components/adminPage/home-carousel/progressBar";
-
-const style = {
-  position: "absolute",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-  width: 400,
-  bgcolor: "background.paper",
-  boxShadow: 24,
-  p: 4,
-  display: "flex",
-  flexDirection: "column",
-  gap: 2,
-  outline: "none",
-};
-
-const Input = styled("input")({
-  display: "none",
-});
 
 const Workers = () => {
   const [workers, setWorkers] = useState([]);
@@ -38,10 +12,11 @@ const Workers = () => {
     name: "",
     rol: "",
   });
-  const [selectedImage, setSelectedImage] = useState(null);
+  const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
-  const [currentWorkerId, setCurrentWorkerId] = useState(null);
+  const [currentWorkerId, setCurrentWorkerId] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     const fetchWorkers = async () => {
@@ -69,6 +44,10 @@ const Workers = () => {
     }
   };
 
+  const openFileDialog = () => {
+    fileInputRef.current?.click();
+  };
+
   const handleOpen = (worker = null) => {
     if (worker) {
       setNewWorker({
@@ -76,6 +55,9 @@ const Workers = () => {
         rol: worker.rol,
       });
       setSelectedImage(null);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
       setCurrentWorkerId(worker.id);
       setEditMode(true);
     } else {
@@ -84,6 +66,9 @@ const Workers = () => {
         rol: "",
       });
       setSelectedImage(null);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
       setCurrentWorkerId(null);
       setEditMode(false);
     }
@@ -92,20 +77,23 @@ const Workers = () => {
 
   const handleClose = () => {
     setSelectedImage(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
     setOpen(false);
   };
 
   const isFormComplete = () => {
-    return (
-      newWorker.name !== "" && newWorker.rol !== "" && selectedImage !== null
-    );
+    return newWorker.name !== "" && newWorker.rol !== "" && selectedImage !== null;
   };
 
   const addNewWorker = async () => {
     const formData = new FormData();
     formData.append("name", newWorker.name);
     formData.append("rol", newWorker.rol);
-    formData.append("image", selectedImage);
+    if (selectedImage) {
+      formData.append("image", selectedImage);
+    }
 
     setUploading(true);
     try {
@@ -114,9 +102,9 @@ const Workers = () => {
           "Content-Type": "multipart/form-data",
         },
         onUploadProgress: (progressEvent) => {
-          const total = progressEvent.total;
+          const total = progressEvent.total || 0;
           const current = progressEvent.loaded;
-          const percentCompleted = Math.round((current / total) * 100);
+          const percentCompleted = total ? Math.round((current / total) * 100) : 0;
           setUploadProgress(percentCompleted);
         },
       });
@@ -132,8 +120,11 @@ const Workers = () => {
   };
 
   const updateWorker = async () => {
+    if (currentWorkerId === null) {
+      return;
+    }
     const formData = new FormData();
-    formData.append("id", currentWorkerId);
+    formData.append("id", String(currentWorkerId));
     formData.append("name", newWorker.name);
     formData.append("rol", newWorker.rol);
     if (selectedImage) {
@@ -147,9 +138,9 @@ const Workers = () => {
           "Content-Type": "multipart/form-data",
         },
         onUploadProgress: (progressEvent) => {
-          const total = progressEvent.total;
+          const total = progressEvent.total || 0;
           const current = progressEvent.loaded;
-          const percentCompleted = Math.round((current / total) * 100);
+          const percentCompleted = total ? Math.round((current / total) * 100) : 0;
           setUploadProgress(percentCompleted);
         },
       });
@@ -190,108 +181,87 @@ const Workers = () => {
         <h1 className="font-serif text-3xl py-5 text-amber-800">
           Trabajadores Actuales
         </h1>
-        <Button
+        <button
+          type="button"
           onClick={() => handleOpen()}
-          variant="contained"
-          startIcon={<AddIcon />}
-          className="bg-blue-600 hover:bg-blue-900 text-white"
+          className="flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         >
-          Añadir Trabajador
-        </Button>
+          <PlusIcon className="h-5 w-5" /> Añadir Trabajador
+        </button>
       </div>
-      <Modal
-        open={open}
-        onClose={(event, reason) => {
-          if (reason !== "backdropClick") {
-            handleClose();
-          }
-        }}
-        aria-labelledby="modal-rol"
-        aria-describedby="modal-description"
-        disableEscapeKeyDown
-        closeAfterTransition
-        slotProps={{
-          backdrop: {
-            style: {
-              backgroundColor: "rgba(0, 0, 0, 0.5)",
-            },
-          },
-        }}
-      >
-        <Box sx={style}>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-            }}
-          >
-            <h2 id="modal-rol">
-              {editMode ? "Editar Trabajador" : "Nuevo Trabajador"}
-            </h2>
-            <IconButton onClick={handleClose}>
-              <CloseIcon />
-            </IconButton>
-          </div>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              height: "180px",
-              backgroundColor: "#f0f0f0",
-              border: "2px dashed #ccc",
-              cursor: "pointer",
-            }}
-            onClick={() => document.getElementById("image-upload").click()}
-          >
-            {selectedImage ? (
-              <img
-                src={URL.createObjectURL(selectedImage)}
-                alt="Selected"
-                style={{ maxHeight: "100%", maxWidth: "100%" }}
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+          <div className="w-full max-w-lg rounded-md bg-white p-6 shadow-xl" role="dialog" aria-modal="true">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-gray-800">
+                {editMode ? "Editar Trabajador" : "Nuevo Trabajador"}
+              </h2>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-md p-1 text-gray-500 transition hover:bg-gray-100"
+                aria-label="Cerrar"
+              >
+                <XMarkIcon className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="mt-4 flex flex-col gap-4">
+              <div
+                className="flex h-44 cursor-pointer items-center justify-center rounded-md border-2 border-dashed border-gray-300 bg-gray-100 p-4 text-center text-sm text-gray-600"
+                onClick={openFileDialog}
+              >
+                {selectedImage ? (
+                  <img
+                    src={URL.createObjectURL(selectedImage)}
+                    alt="Selected"
+                    className="h-full w-full object-contain"
+                  />
+                ) : (
+                  <span>Haz clic para seleccionar una imagen</span>
+                )}
+              </div>
+              <input
+                ref={fileInputRef}
+                accept="image/*"
+                id="image-upload"
+                type="file"
+                className="hidden"
+                onChange={handleImageChange}
               />
-            ) : (
-              <span>Haz clic para seleccionar una imagen</span>
-            )}
+              <input
+                type="text"
+                name="name"
+                value={newWorker.name}
+                onChange={handleChange}
+                placeholder="Nombre"
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+              />
+              <input
+                type="text"
+                name="rol"
+                value={newWorker.rol}
+                onChange={handleChange}
+                placeholder="Rol"
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+              />
+              <button
+                type="button"
+                onClick={editMode ? updateWorker : addNewWorker}
+                disabled={!isFormComplete()}
+                className="rounded-md bg-blue-600 px-4 py-2 font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-blue-300"
+              >
+                Confirmar
+              </button>
+            </div>
           </div>
-          <Input
-            accept="image/*"
-            id="image-upload"
-            type="file"
-            onChange={handleImageChange}
-          />
-          <TextField
-            label="Nombre"
-            type="text"
-            name="name"
-            value={newWorker.name}
-            onChange={handleChange}
-            fullWidth
-          />
-          <TextField
-            label="Rol"
-            type="text"
-            name="rol"
-            value={newWorker.rol}
-            onChange={handleChange}
-            fullWidth
-          />
-          <Button
-            onClick={editMode ? updateWorker : addNewWorker}
-            variant="contained"
-            className="bg-blue-600 hover:bg-blue-900 text-white"
-            sx={{ mt: 2 }}
-            disabled={!isFormComplete()}
-          >
-            Confirmar
-          </Button>
-        </Box>
-      </Modal>
+        </div>
+      )}
+
       <h1 className="text-center font-serif text-2xl py-5 mt-8">
         Trabajadores Actuales
       </h1>
-      <div className=" p-5" id="us">
+      <div className="p-5" id="us">
         <div className="flex flex-wrap justify-center gap-8">
           {workers.map((worker) => (
             <div
@@ -306,22 +276,20 @@ const Workers = () => {
               <p className="mt-4 font-semibold text-gray-800">{worker.name}</p>
               <p className="text-sm text-gray-600">{worker.rol}</p>
               <div className="relative bottom-52 left-2 flex space-x-2">
-                <Button
-                  className="bg-blue-600 hover:bg-blue-900 text-white"
-                  variant="contained"
-                  color="info"
+                <button
+                  type="button"
+                  className="rounded-md bg-blue-600 px-3 py-1 text-sm font-semibold text-white transition hover:bg-blue-700"
                   onClick={() => handleOpen(worker)}
                 >
                   Editar
-                </Button>
-                <Button
-                  className="bg-red-600 hover:bg-red-900 text-white"
-                  variant="contained"
-                  color="warning"
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md bg-red-600 px-3 py-1 text-sm font-semibold text-white transition hover:bg-red-700"
                   onClick={() => deleteWorker(worker.id)}
                 >
                   Eliminar
-                </Button>
+                </button>
               </div>
             </div>
           ))}

--- a/components/btnHome.tsx
+++ b/components/btnHome.tsx
@@ -1,14 +1,13 @@
 import Link from "next/link";
-import KeyboardReturnIcon from "@mui/icons-material/KeyboardReturn";
+import { ChevronLeftIcon } from "@components/icons";
+
 export default function BtnHome() {
   return (
-    <Link href="/" className="absolute left-0" passHref>
-      <button
-        type="button"
-        className="text-white shadow-lg p-2 bg-gray-500 rounded-r-md text-sm pr-3 tracking-wider"
-      >
-        <KeyboardReturnIcon /> INICIO
-      </button>
+    <Link href="/" className="absolute left-0">
+      <span className="flex items-center gap-2 rounded-r-md bg-gray-500 px-3 py-2 text-sm font-semibold uppercase tracking-wide text-white shadow-lg transition hover:bg-gray-600">
+        <ChevronLeftIcon className="h-4 w-4" />
+        Inicio
+      </span>
     </Link>
   );
 }

--- a/components/carrousel.tsx
+++ b/components/carrousel.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
-import ArrowBackIosNewRoundedIcon from '@mui/icons-material/ArrowBackIosNewRounded';
-import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRounded';
+import { ChevronLeftIcon, ChevronRightIcon } from "@components/icons";
 
 const Carrousel = () => {
   const [slides, setSlides] = useState([]);
@@ -24,18 +23,17 @@ const Carrousel = () => {
 
   useEffect(() => {
     const interv = setInterval(() => {
-      nextSlide();
+      setCurrent((prev) => (prev === slides.length - 1 ? 0 : prev + 1));
     }, 10000);
     return () => clearInterval(interv);
-  }, [current]);
+  }, [slides.length]);
 
   const prevSlide = () => {
-    if (current === 0) setCurrent(slides.length - 1);
-    else setCurrent(current - 1);
+    setCurrent((prev) => (prev === 0 ? slides.length - 1 : prev - 1));
   };
 
   const nextSlide = () => {
-    current === slides.length - 1 ? setCurrent(0) : setCurrent(current + 1);
+    setCurrent((prev) => (prev === slides.length - 1 ? 0 : prev + 1));
   };
 
   return (
@@ -49,15 +47,20 @@ const Carrousel = () => {
         >
           {slides.map((s, i) => (
             <div className="flex justify-center w-full h-full flex-shrink-0" key={i}>
-              <img src={s.imag} className="w-auto h-full object-cover" />
+              <img src={s.imag} className="w-auto h-full object-cover" alt={`Imagen del carrusel ${i + 1}`} />
             </div>
           ))}
         </div>
       </div>
 
       <div className="relative bottom-9 flex w-full gap-3 justify-center items-center text-gray-200">
-        <button onClick={prevSlide}>
-          <ArrowBackIosNewRoundedIcon className="text-lg" />
+        <button
+          type="button"
+          onClick={prevSlide}
+          aria-label="Anterior"
+          className="rounded-full bg-black/40 p-1 text-gray-100 transition hover:bg-black/60"
+        >
+          <ChevronLeftIcon className="h-5 w-5" />
         </button>
         {slides.map((x, i) => (
           <div
@@ -68,8 +71,13 @@ const Carrousel = () => {
             className={`rounded-full w-2 h-2 cursor-pointer ${i === current ? "bg-gray-200" : "bg-gray-500"}`}
           ></div>
         ))}
-        <button onClick={nextSlide}>
-          <ArrowForwardIosRoundedIcon className="text-lg" />
+        <button
+          type="button"
+          onClick={nextSlide}
+          aria-label="Siguiente"
+          className="rounded-full bg-black/40 p-1 text-gray-100 transition hover:bg-black/60"
+        >
+          <ChevronRightIcon className="h-5 w-5" />
         </button>
       </div>
     </div>

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+
+type IconProps = React.SVGProps<SVGSVGElement>;
+
+const IconBase = ({ className, children, ...props }: IconProps & { children: React.ReactNode }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    {...props}
+  >
+    {children}
+  </svg>
+);
+
+export const ArrowRightOnRectangleIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <path d="M13 6H8a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h5" />
+    <path d="M9 12h12" />
+    <path d="m19 8 4 4-4 4" />
+  </IconBase>
+);
+
+export const LockClosedIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <rect x="5" y="11" width="14" height="9" rx="2" ry="2" />
+    <path d="M9 11V8a3 3 0 0 1 6 0v3" />
+    <path d="M12 15v2" />
+  </IconBase>
+);
+
+export const UserIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <circle cx="12" cy="8" r="3.5" />
+    <path d="M6 20c0-3.3 2.7-6 6-6s6 2.7 6 6" />
+  </IconBase>
+);
+
+export const ChevronLeftIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <path d="m14 6-6 6 6 6" />
+  </IconBase>
+);
+
+export const ChevronRightIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <path d="m10 6 6 6-6 6" />
+  </IconBase>
+);
+
+export const ChevronUpIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <path d="m6 15 6-6 6 6" />
+  </IconBase>
+);
+
+export const Bars3Icon = (props: IconProps) => (
+  <IconBase {...props}>
+    <path d="M4 7h16" />
+    <path d="M4 12h16" />
+    <path d="M4 17h16" />
+  </IconBase>
+);
+
+export const XMarkIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <path d="M6 6l12 12" />
+    <path d="M18 6 6 18" />
+  </IconBase>
+);
+
+export const PlusIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <path d="M12 5v14" />
+    <path d="M5 12h14" />
+  </IconBase>
+);
+
+export const ArrowUpTrayIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <path d="m12 4-4 4" />
+    <path d="m12 4 4 4" />
+    <path d="M12 4v12" />
+    <path d="M5 20h14" />
+  </IconBase>
+);
+
+export const TrashIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <path d="M5 7h14" />
+    <path d="M9 7V5h6v2" />
+    <path d="M10 11v6" />
+    <path d="M14 11v6" />
+    <path d="M7 7l1 12a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2l1-12" />
+  </IconBase>
+);
+
+export const CalendarDaysIcon = (props: IconProps) => (
+  <IconBase {...props}>
+    <rect x="4" y="6" width="16" height="14" rx="2" ry="2" />
+    <path d="M4 10h16" />
+    <path d="M8 2v4" />
+    <path d="M16 2v4" />
+  </IconBase>
+);
+
+export const ArrowRightIcon = ArrowRightOnRectangleIcon;

--- a/components/langChanger.tsx
+++ b/components/langChanger.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import KeyboardArrowUpRoundedIcon from "@mui/icons-material/KeyboardArrowUpRounded";
+import { ChevronUpIcon } from "@components/icons";
 
 const flags = [
   { code: "en", imgF: "/icons/flags/en.png" },
@@ -15,7 +15,8 @@ const LangChanger = () => {
   const [selectedFlag, setSelectedFlag] = useState(
     () => flags.find((flag) => flag.code === i18n.language) || flags[1]
   );
-  const dropdownRef = useRef(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const fileId = selectedFlag.code;
 
   const toggleDropdown = () => {
     setIsOpen(!isOpen);
@@ -28,8 +29,8 @@ const LangChanger = () => {
   };
 
   useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);
       }
     };
@@ -37,37 +38,45 @@ const LangChanger = () => {
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [isOpen]);
+  }, []);
 
   useEffect(() => {
     const currentFlag = flags.find((flag) => flag.code === i18n.language);
     if (currentFlag && currentFlag.code !== selectedFlag.code) {
       setSelectedFlag(currentFlag);
     }
-  }, [i18n.language]);
+  }, [i18n.language, selectedFlag.code]);
 
   return (
-    <div className={`relative ml-2 p-1 ${isOpen ? "bg-yellow-100" : ""}`} ref={dropdownRef}>
-      <button onClick={toggleDropdown} className="flex items-center">
+    <div
+      ref={dropdownRef}
+      className={`relative ml-2 rounded-md p-1 transition ${isOpen ? "bg-yellow-100" : ""}`}
+    >
+      <button onClick={toggleDropdown} className="flex items-center gap-1">
         <img
           src={selectedFlag.imgF}
-          alt={selectedFlag.code + " flag"}
-          className="w-6 h-6"
+          alt={`${selectedFlag.code} flag`}
+          className="h-6 w-6"
         />
-        <KeyboardArrowUpRoundedIcon className={`text-amber-900 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`} />
+        <ChevronUpIcon
+          className={`h-4 w-4 text-amber-900 transition-transform duration-200 ${
+            isOpen ? "rotate-180" : ""
+          }`}
+        />
       </button>
       {isOpen && (
-        <div className="flex flex-col mt-2 absolute z-20 top-6 right-6 bg-yellow-100 items-center pt-1">
+        <div className="absolute right-0 top-8 z-20 flex flex-col items-center gap-1 rounded-md bg-yellow-100 p-2 shadow-md">
           {flags
             .filter((flag) => flag.code !== selectedFlag.code)
-            .map((flag, index) => (
-              <img
-                key={index}
-                src={flag.imgF}
-                alt={`${flag.code} flag`}
-                className="w-6 h-6 m-1 cursor-pointer"
+            .map((flag) => (
+              <button
+                key={`${fileId}-${flag.code}`}
+                type="button"
                 onClick={() => handleSelectFlag(flag)}
-              />
+                className="rounded-md p-1 transition hover:bg-yellow-200"
+              >
+                <img src={flag.imgF} alt={`${flag.code} flag`} className="h-6 w-6" />
+              </button>
             ))}
         </div>
       )}

--- a/components/loading.tsx
+++ b/components/loading.tsx
@@ -1,11 +1,9 @@
-import CircularProgress from "@mui/material/CircularProgress";
-
 const Loading = () => {
   return (
-	<div className="flex relative place-content-center top-72">
-	<CircularProgress />
-  </div>
-  )
-}
+    <div className="flex min-h-[50vh] items-center justify-center">
+      <div className="h-12 w-12 animate-spin rounded-full border-4 border-amber-800 border-t-transparent" />
+    </div>
+  );
+};
 
-export default Loading
+export default Loading;

--- a/components/navMobile.tsx
+++ b/components/navMobile.tsx
@@ -1,99 +1,76 @@
 "use client";
-import { cloneElement, useState } from "react";
-import AppBar from "@mui/material/AppBar";
-import Toolbar from "@mui/material/Toolbar";
-import CssBaseline from "@mui/material/CssBaseline";
-import useScrollTrigger from "@mui/material/useScrollTrigger";
-import IconButton from "@mui/material/IconButton";
-import Drawer from "@mui/material/Drawer";
-import MenuIcon from "@mui/icons-material/Menu";
-import CloseIcon from "@mui/icons-material/Close";
+import { useEffect, useState } from "react";
 import Link from "next/link";
+import { Bars3Icon, XMarkIcon } from "@components/icons";
 import LangChanger from "./langChanger";
 import NavText from "./navText";
 
-function ElevationScroll(props) {
-  const { children, window } = props;
-  const trigger = useScrollTrigger({
-    disableHysteresis: true,
-    threshold: 0,
-    target: window ? window() : undefined,
-  });
-
-  return cloneElement(children, {
-    style: {
-      backgroundColor:"white" ,
-      boxShadow: trigger ? "0px 4px 12px rgba(0, 0, 0, 0.1)" : "none",
-      transition: "box-shadow 0.3s ease-in-out, background-color 0.3s ease-in-out",
-    },
-  });
-}
-
 function NavMobile({ isMobile }) {
+  const [scrolled, setScrolled] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 0);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const toggleDrawer = () => setIsDrawerOpen((prev) => !prev);
+  const closeDrawer = () => setIsDrawerOpen(false);
 
   return (
     <>
-      <CssBaseline />
-      <ElevationScroll>
-        <AppBar position="fixed" style={{ boxShadow: "none" }}>
-          <Toolbar>
-            <Link href="/">
-              <h1 className="text-amber-900 font-playfair text-2xl">
-                San Juan Bautista de Remedios
-              </h1>
-            </Link>
-            <div style={{ flexGrow: 1 }} />
-            <LangChanger />
-            <IconButton
-              onClick={() => setIsDrawerOpen(!isDrawerOpen)}
-              sx={{
-                "&:hover": {
-                  backgroundColor: "transparent",
-                },
-              }}
-            >
-              <MenuIcon
-                style={{ fontSize: "30px", background: "white" }}
-                className="iconClose"
-              />
-            </IconButton>
-          </Toolbar>
-        </AppBar>
-      </ElevationScroll>
-      <Toolbar />
-      <Drawer
-        anchor="right"
-        open={isDrawerOpen}
-        onClose={() => setIsDrawerOpen(false)}
-        PaperProps={{
-          sx: {
-            width: "250px",
-            background: "white",
-            boxShadow: "none",
-          },
-        }}
-        transitionDuration={300} // Adjust duration for smoother animation
+      <header
+        className={`fixed top-0 z-50 w-full bg-white transition-shadow duration-300 ${
+          scrolled ? "shadow-md" : "shadow-none"
+        }`}
       >
-        <div
-          role="presentation"
-          onClick={() => setIsDrawerOpen(false)}
-          onKeyDown={() => setIsDrawerOpen(false)}
-          style={{ width: 250 }}
-        >
-          <IconButton
-            onClick={() => setIsDrawerOpen(false)}
-            sx={{
-              "&:hover": {
-                backgroundColor: "white",
-              },
-            }}
-          >
-            <CloseIcon style={{ fontSize: "30px", background: "white" }} />
-          </IconButton>
-          <NavText isMobile={isMobile} />
+        <div className="flex items-center justify-between px-4 py-3">
+          <Link href="/">
+            <h1 className="text-amber-900 font-playfair text-lg">
+              San Juan Bautista de Remedios
+            </h1>
+          </Link>
+          <div className="flex items-center gap-3">
+            <LangChanger />
+            <button
+              type="button"
+              onClick={toggleDrawer}
+              aria-label="Abrir menú"
+              className="rounded-md p-2 text-amber-900 transition hover:bg-amber-100"
+            >
+              <Bars3Icon className="h-7 w-7" />
+            </button>
+          </div>
         </div>
-      </Drawer>
+      </header>
+      <div className="h-16" />
+      {isDrawerOpen && (
+        <div className="fixed inset-0 z-40 flex">
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={closeDrawer}
+            aria-hidden="true"
+          />
+          <aside className="relative ml-auto flex h-full w-64 flex-col bg-white p-4 shadow-lg transition-transform">
+            <button
+              type="button"
+              onClick={closeDrawer}
+              aria-label="Cerrar menú"
+              className="self-end rounded-md p-2 text-amber-900 transition hover:bg-amber-100"
+            >
+              <XMarkIcon className="h-6 w-6" />
+            </button>
+            <nav className="mt-4">
+              <NavText isMobile={isMobile} />
+            </nav>
+          </aside>
+        </div>
+      )}
     </>
   );
 }

--- a/components/navPC.tsx
+++ b/components/navPC.tsx
@@ -1,50 +1,43 @@
 "use client";
 
-import AppBar from "@mui/material/AppBar";
-import Toolbar from "@mui/material/Toolbar";
-import CssBaseline from "@mui/material/CssBaseline";
-import useScrollTrigger from "@mui/material/useScrollTrigger";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import LangChanger from "./langChanger";
 import NavText from "./navText";
-import { cloneElement } from "react";
-
-function ElevationScroll(props) {
-  const { children, window } = props;
-  const trigger = useScrollTrigger({
-    disableHysteresis: true,
-    threshold: 0,
-    target: window ? window() : undefined,
-  });
-
-  return cloneElement(children, {
-    style: {
-      backgroundColor:"white" ,
-      boxShadow: trigger ? "0px 4px 12px rgba(0, 0, 0, 0.1)" : "none",
-      transition: trigger ? "box-shadow 0.3s ease-in-out" : "none",
-    },
-  });
-}
 
 function NavPC({ isMobile }) {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 0);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
   return (
     <>
-      <CssBaseline />
-      <ElevationScroll>
-        <AppBar position="fixed" style={{ boxShadow: "none" }}>
-          <Toolbar>
-            <Link href="/">
-              <h1 className="text-amber-900 font-playfair text-2xl">
-                San Juan Bautista de Remedios
-              </h1>
-            </Link>
-            <div style={{ flexGrow: 1 }} />
+      <header
+        className={`fixed top-0 z-50 w-full bg-white transition-shadow duration-300 ${
+          scrolled ? "shadow-md" : "shadow-none"
+        }`}
+      >
+        <div className="mx-auto flex max-w-6xl items-center px-4 py-3 md:px-8">
+          <Link href="/">
+            <h1 className="text-amber-900 font-playfair text-lg sm:text-xl md:text-2xl">
+              San Juan Bautista de Remedios
+            </h1>
+          </Link>
+          <div className="flex flex-1 items-center justify-end gap-6">
             <NavText isMobile={isMobile} />
             <LangChanger />
-          </Toolbar>
-        </AppBar>
-      </ElevationScroll>
-      <Toolbar />
+          </div>
+        </div>
+      </header>
+      <div className="h-16" />
     </>
   );
 }

--- a/components/noticias/cards.tsx
+++ b/components/noticias/cards.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState } from "react";
-import CalendarTodayOutlinedIcon from "@mui/icons-material/CalendarTodayOutlined";
+import { CalendarDaysIcon } from "@components/icons";
 import DialogCard from "./dialog";
 
 const Cards = ({ title, text, imageUrl, date, itemKey }) => {
@@ -27,7 +27,7 @@ const Cards = ({ title, text, imageUrl, date, itemKey }) => {
           </div>
           <div className="flex flex-col p-4 gap-y-1 text-gray-500 ">
             <div className="flex items-center gap-2 ">
-              <CalendarTodayOutlinedIcon className="text-xs" />
+              <CalendarDaysIcon className="h-4 w-4 text-amber-700" />
               <p className="text-xs">{date}</p>
             </div>
             <h1 className="text-base text-black font-semibold">{title}</h1>

--- a/components/noticias/dialog.tsx
+++ b/components/noticias/dialog.tsx
@@ -1,39 +1,47 @@
-import Dialog from "@mui/material/Dialog";
-import DialogTitle from "@mui/material/DialogTitle";
-import DialogContent from "@mui/material/DialogContent";
-import DialogContentText from "@mui/material/DialogContentText";
-import DialogActions from "@mui/material/DialogActions";
-import Button from "@mui/material/Button";
+interface DialogCardProps {
+  open: boolean;
+  handleClose: () => void;
+  title: string;
+  date: string;
+  text: string;
+  imageUrl: string;
+}
 
-function DialogCard({ open, handleClose, title, date, text, imageUrl }) {
+function DialogCard({ open, handleClose, title, date, text, imageUrl }: DialogCardProps) {
+  if (!open) return null;
+
   return (
-    <Dialog
-      open={open}
-      onClose={handleClose}
-      className="flex justify-center"
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="dialog-title"
+      onClick={handleClose}
     >
-      <div className="flex flex-col items-center p-3">
-        <div className="overflow-hidden rounded-t-sm w-64 h-40">
-          <img 
-            src={imageUrl} 
-            alt={title} 
-            className="object-cover w-full h-full"
-          />
+      <div
+        className="flex w-full max-w-md flex-col items-center overflow-hidden rounded-md bg-white shadow-lg"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="h-48 w-full overflow-hidden">
+          <img src={imageUrl} alt={title} className="h-full w-full object-cover" />
         </div>
-        <DialogTitle className="text-center w-full font-serif ">
-          {title}
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText className="font-sans text-center text-gray-800 mb-4">{date}</DialogContentText>
-          <DialogContentText className="font-sans">{text}</DialogContentText>
-        </DialogContent>
-        <DialogActions className="flex w-full justify-end">
-          <Button onClick={handleClose} color="primary" className="font-serif">
-            Cerrar
-          </Button>
-        </DialogActions>
+        <div className="flex w-full flex-col gap-3 px-6 py-4 text-center">
+          <h2 id="dialog-title" className="font-serif text-xl text-gray-900">
+            {title}
+          </h2>
+          <p className="text-sm text-gray-600">{date}</p>
+          <p className="text-sm leading-relaxed text-gray-700">{text}</p>
+          <div className="mt-4 flex justify-end">
+            <button
+              onClick={handleClose}
+              className="rounded-md bg-amber-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
+            >
+              Cerrar
+            </button>
+          </div>
+        </div>
       </div>
-    </Dialog>
+    </div>
   );
 }
 

--- a/components/socialMedia.tsx
+++ b/components/socialMedia.tsx
@@ -1,20 +1,38 @@
 import React from "react";
-import InstagramIcon from "@mui/icons-material/Instagram";
-import FacebookIcon from "@mui/icons-material/Facebook";
-import YouTubeIcon from "@mui/icons-material/YouTube";
 import Link from "next/link";
+
+const iconClasses = "h-7 w-7 fill-current";
+
+const InstagramIcon = () => (
+  <svg viewBox="0 0 24 24" className={iconClasses} aria-hidden="true">
+    <path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.9.3 2.3.5.6.2 1 .5 1.4.9s.7.8.9 1.4c.2.4.4 1 .5 2.3.1 1.3.1 1.7.1 4.9s0 3.6-.1 4.9c-.1 1.2-.3 1.9-.5 2.3-.2.6-.5 1-1 1.4-.4.4-.8.7-1.4.9-.4.2-1 .4-2.3.5-1.3.1-1.7.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.9-.3-2.3-.5-.6-.2-1-.5-1.4-.9s-.7-.8-.9-1.4c-.2-.4-.4-1-.5-2.3C2.2 15.6 2.2 15.2 2.2 12s0-3.6.1-4.9c.1-1.2.3-1.9.5-2.3.2-.6.5-1 1-1.4.4-.4.8-.7 1.4-.9.4-.2 1-.4 2.3-.5C8.4 2.2 8.8 2.2 12 2.2m0-2.2C8.7 0 8.3 0 7 0 5.7 0 4.8.2 4 .5c-.9.3-1.6.7-2.3 1.4C1 2.6.6 3.3.3 4.2.1 5 .1 5.9.1 7.2 0 8.5 0 8.9 0 12c0 3.1 0 3.5.1 4.8.1 1.3.2 2.2.5 3 .3.9.7 1.6 1.4 2.3.7.7 1.4 1.1 2.3 1.4.8.3 1.7.5 3 .5 1.3.1 1.7.1 4.8.1 3.1 0 3.5 0 4.8-.1 1.3-.1 2.2-.2 3-.5.9-.3 1.6-.7 2.3-1.4.7-.7 1.1-1.4 1.4-2.3.3-.8.5-1.7.5-3 .1-1.3.1-1.7.1-4.8s0-3.5-.1-4.8c-.1-1.3-.2-2.2-.5-3-.3-.9-.7-1.6-1.4-2.3C21.4 1 20.7.6 19.8.3c-.8-.3-1.7-.5-3-.5C15.5 0 15.1 0 12 0Z" />
+    <path d="M12 5.8a6.2 6.2 0 1 0 6.2 6.2A6.2 6.2 0 0 0 12 5.8Zm0 10.2A4 4 0 1 1 16 12a4 4 0 0 1-4 4Zm6.4-11.2a1.4 1.4 0 1 1-1.4-1.4 1.4 1.4 0 0 1 1.4 1.4Z" />
+  </svg>
+);
+
+const FacebookIcon = () => (
+  <svg viewBox="0 0 24 24" className={iconClasses} aria-hidden="true">
+    <path d="M22.7 0H1.3C.6 0 0 .6 0 1.3v21.4C0 23.4.6 24 1.3 24h11.5v-9.3H9.7V11h3.1V8.4c0-3.1 1.9-4.8 4.6-4.8 1.3 0 2.6.1 2.9.1v3.4h-2c-1.6 0-1.9.8-1.9 1.8V11h3.7l-.5 3.7h-3.2V24h6.3c.7 0 1.3-.6 1.3-1.3V1.3C24 .6 23.4 0 22.7 0Z" />
+  </svg>
+);
+
+const YouTubeIcon = () => (
+  <svg viewBox="0 0 24 24" className={iconClasses} aria-hidden="true">
+    <path d="M23.5 6.2a2.9 2.9 0 0 0-2-2C19.4 3.8 12 3.8 12 3.8s-7.4 0-9.5.4a2.9 2.9 0 0 0-2 2C0 8.3 0 12 0 12s0 3.7.5 5.8a2.9 2.9 0 0 0 2 2c2.1.4 9.5.4 9.5.4s7.4 0 9.5-.4a2.9 2.9 0 0 0 2-2c.5-2.1.5-5.8.5-5.8s0-3.7-.5-5.8ZM9.6 15.3V8.7l6.3 3.3Z" />
+  </svg>
+);
 
 const SocialMedia = () => {
   return (
-    <div className="flex gap-3 mt-1 ml-[-3px]">
-      <Link href={"asd"}>
-        <InstagramIcon className="text-3xl" />
+    <div className="flex gap-3 mt-1">
+      <Link href="asd" aria-label="Instagram" className="text-rose-500 transition hover:text-rose-600">
+        <InstagramIcon />
       </Link>
-      <Link href={"sdf"}>
-        <FacebookIcon className="text-3xl" />
+      <Link href="sdf" aria-label="Facebook" className="text-blue-600 transition hover:text-blue-700">
+        <FacebookIcon />
       </Link>
-      <Link href={"ad"}>
-        <YouTubeIcon className="text-3xl" />
+      <Link href="ad" aria-label="YouTube" className="text-red-600 transition hover:text-red-700">
+        <YouTubeIcon />
       </Link>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -9,11 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@emotion/react": "^11.11.4",
-    "@emotion/styled": "^11.11.0",
-    "@fontsource/roboto": "^5.0.13",
-    "@mui/icons-material": "^5.15.11",
-    "@mui/material": "^5.15.11",
     "@stripe/react-stripe-js": "^2.7.1",
     "@stripe/stripe-js": "^3.5.0",
     "axios": "^1.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,21 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@emotion/react':
-        specifier: ^11.11.4
-        version: 11.14.0(@types/react@18.3.24)(react@18.3.1)
-      '@emotion/styled':
-        specifier: ^11.11.0
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
-      '@fontsource/roboto':
-        specifier: ^5.0.13
-        version: 5.2.8
-      '@mui/icons-material':
-        specifier: ^5.15.11
-        version: 5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
-      '@mui/material':
-        specifier: ^5.15.11
-        version: 5.18.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@stripe/react-stripe-js':
         specifier: ^2.7.1
         version: 2.9.0(@stripe/stripe-js@3.5.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -175,60 +160,6 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
-  '@emotion/babel-plugin@11.13.5':
-    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
-
-  '@emotion/cache@11.14.0':
-    resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
-
-  '@emotion/hash@0.9.2':
-    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
-
-  '@emotion/is-prop-valid@1.4.0':
-    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
-
-  '@emotion/memoize@0.9.0':
-    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
-
-  '@emotion/react@11.14.0':
-    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@emotion/serialize@1.3.3':
-    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
-
-  '@emotion/sheet@1.4.0':
-    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
-
-  '@emotion/styled@11.14.1':
-    resolution: {integrity: sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==}
-    peerDependencies:
-      '@emotion/react': ^11.0.0-rc.0
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@emotion/unitless@0.10.0':
-    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
-
-  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
-    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
-    peerDependencies:
-      react: '>=16.8.0'
-
-  '@emotion/utils@1.4.2':
-    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
-
-  '@emotion/weak-memoize@0.4.0':
-    resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
-
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -246,9 +177,6 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  '@fontsource/roboto@5.2.8':
-    resolution: {integrity: sha512-oh9g4Cg3loVMz9MWeKWfDI+ooxxG1aRVetkiKIb2ESS2rrryGecQ/y4pAj4z5A5ebyw450dYRi/c4k/I3UBhHA==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -279,94 +207,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@mui/core-downloads-tracker@5.18.0':
-    resolution: {integrity: sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==}
-
-  '@mui/icons-material@5.18.0':
-    resolution: {integrity: sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@mui/material': ^5.0.0
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/material@5.18.0':
-    resolution: {integrity: sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@types/react':
-        optional: true
-
-  '@mui/private-theming@5.17.1':
-    resolution: {integrity: sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/styled-engine@5.18.0':
-    resolution: {integrity: sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.4.1
-      '@emotion/styled': ^11.3.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-
-  '@mui/system@5.18.0':
-    resolution: {integrity: sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@types/react':
-        optional: true
-
-  '@mui/types@7.2.24':
-    resolution: {integrity: sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/utils@5.17.1':
-    resolution: {integrity: sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -2669,89 +2509,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emotion/babel-plugin@11.13.5':
-    dependencies:
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/runtime': 7.28.4
-      '@emotion/hash': 0.9.2
-      '@emotion/memoize': 0.9.0
-      '@emotion/serialize': 1.3.3
-      babel-plugin-macros: 3.1.0
-      convert-source-map: 1.9.0
-      escape-string-regexp: 4.0.0
-      find-root: 1.1.0
-      source-map: 0.5.7
-      stylis: 4.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/cache@11.14.0':
-    dependencies:
-      '@emotion/memoize': 0.9.0
-      '@emotion/sheet': 1.4.0
-      '@emotion/utils': 1.4.2
-      '@emotion/weak-memoize': 0.4.0
-      stylis: 4.2.0
-
-  '@emotion/hash@0.9.2': {}
-
-  '@emotion/is-prop-valid@1.4.0':
-    dependencies:
-      '@emotion/memoize': 0.9.0
-
-  '@emotion/memoize@0.9.0': {}
-
-  '@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      '@emotion/weak-memoize': 0.4.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.24
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/serialize@1.3.3':
-    dependencies:
-      '@emotion/hash': 0.9.2
-      '@emotion/memoize': 0.9.0
-      '@emotion/unitless': 0.10.0
-      '@emotion/utils': 1.4.2
-      csstype: 3.1.3
-
-  '@emotion/sheet@1.4.0': {}
-
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.24
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/unitless@0.10.0': {}
-
-  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-
-  '@emotion/utils@1.4.2': {}
-
-  '@emotion/weak-memoize@0.4.0': {}
-
   '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
@@ -2774,8 +2531,6 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
-
-  '@fontsource/roboto@5.2.8': {}
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -2811,90 +2566,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@mui/core-downloads-tracker@5.18.0': {}
-
-  '@mui/icons-material@5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@mui/material': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.24
-
-  '@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@mui/core-downloads-tracker': 5.18.0
-      '@mui/system': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
-      '@mui/types': 7.2.24(@types/react@18.3.24)
-      '@mui/utils': 5.17.1(@types/react@18.3.24)(react@18.3.1)
-      '@popperjs/core': 2.11.8
-      '@types/react-transition-group': 4.4.12(@types/react@18.3.24)
-      clsx: 2.1.1
-      csstype: 3.1.3
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-is: 19.1.1
-      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
-      '@types/react': 18.3.24
-
-  '@mui/private-theming@5.17.1(@types/react@18.3.24)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@mui/utils': 5.17.1(@types/react@18.3.24)(react@18.3.1)
-      prop-types: 15.8.1
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.24
-
-  '@mui/styled-engine@5.18.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      csstype: 3.1.3
-      prop-types: 15.8.1
-      react: 18.3.1
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
-
-  '@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@mui/private-theming': 5.17.1(@types/react@18.3.24)(react@18.3.1)
-      '@mui/styled-engine': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)
-      '@mui/types': 7.2.24(@types/react@18.3.24)
-      '@mui/utils': 5.17.1(@types/react@18.3.24)(react@18.3.1)
-      clsx: 2.1.1
-      csstype: 3.1.3
-      prop-types: 15.8.1
-      react: 18.3.1
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
-      '@types/react': 18.3.24
-
-  '@mui/types@7.2.24(@types/react@18.3.24)':
-    optionalDependencies:
-      '@types/react': 18.3.24
-
-  '@mui/utils@5.17.1(@types/react@18.3.24)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@mui/types': 7.2.24(@types/react@18.3.24)
-      '@types/prop-types': 15.7.15
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-is: 19.1.1
-    optionalDependencies:
-      '@types/react': 18.3.24
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:


### PR DESCRIPTION
## Summary
- replace Material UI components in the login, donations, and admin management views with Tailwind-driven forms and modals
- introduce a reusable SVG icon library and update navigation, carousel, and social UI to rely on it instead of Material UI icons
- remove Material UI dependencies and refresh progress/loading feedback using Tailwind overlays

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ced8b63d38832caafa344d7c15ebf1