### PR TITLE
feat: refresh theme colors and typography

### DIFF
--- a/src/frontend/app/donations/page.tsx
+++ b/src/frontend/app/donations/page.tsx
@@ -82,10 +82,10 @@ const DonateForm = () => {
     <><BtnHome/>
     <form
       onSubmit={handleSubmit}
-      className="flex flex-col justify-center items-center p-4 bg-gray-200 h-screen rounded-md shadow-md"
+      className="flex flex-col justify-center items-center p-4 bg-sanctuaryCream h-screen rounded-md shadow-md"
     >
-      
-      <h2 className="mb-4 text-center text-2xl font-bold">Donar</h2>
+
+      <h2 className="mb-4 text-center text-2xl font-display text-sanctuaryBrick">Donar</h2>
       <div className="mb-3 w-[265px]">
         <label htmlFor="paymentMethod" className="sr-only">
           Método de pago
@@ -95,7 +95,7 @@ const DonateForm = () => {
           name="paymentMethod"
           value={paymentMethod}
           onChange={(e) => setPaymentMethod(e.target.value)}
-          className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+          className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:border-sanctuaryTerracotta focus:outline-none focus:ring-1 focus:ring-sanctuaryTerracotta"
         >
           <option value="1" disabled>
             Seleccione un método de pago
@@ -107,7 +107,7 @@ const DonateForm = () => {
       {paymentMethod === "stripe" && (
         <>
           <div className="mb-4">
-            <h3 className="text-lg font-semibold mb-2 text-center">
+            <h3 className="text-lg font-display mb-2 text-center text-sanctuaryBrick">
               Selecciona un monto:
             </h3>
             <div className="grid grid-cols-2 justify-center gap-2">
@@ -115,10 +115,10 @@ const DonateForm = () => {
                 <button
                   key={value}
                   type="button"
-                  className={`p-1 w-32 h-10 rounded-md border ${
+                  className={`p-1 w-32 h-10 rounded-md border transition ${
                     amount === value
-                      ? "bg-blue-500 text-white"
-                      : "bg-white text-blue-500"
+                      ? "bg-sanctuaryTerracotta text-white border-sanctuaryTerracotta"
+                      : "bg-white text-sanctuaryTerracotta border-sanctuaryTerracotta hover:bg-sanctuaryGold/20"
                   }`}
                   onClick={() => handleAmountClick(value)}
                 >
@@ -133,7 +133,7 @@ const DonateForm = () => {
               id="amount"
               name="amount"
               placeholder="Monto personalizado"
-              className="p-2 w-[265px] border rounded-md"
+              className="p-2 w-[265px] border rounded-md focus:border-sanctuaryTerracotta focus:outline-none focus:ring-1 focus:ring-sanctuaryTerracotta"
               value={amount}
               onChange={handleAmountChange}
               required
@@ -144,10 +144,10 @@ const DonateForm = () => {
       <div className="flex flex-col gap-y-5 justify-center items-center">
         <button
           type="submit"
-          className={`flex font-serif font-semibold p-2 gap-3 rounded-md w-[265px] justify-center shadow-md text-white ${
+          className={`flex font-display font-semibold p-2 gap-3 rounded-md w-[265px] justify-center shadow-md text-white transition ${
             paymentMethod === "1"
               ? "bg-gray-400 cursor-not-allowed"
-              : "bg-amber-600 "
+              : "bg-sanctuaryTerracotta hover:bg-sanctuaryBrick"
           }`}
           disabled={paymentMethod === "1"}
         >

--- a/src/frontend/app/layout.tsx
+++ b/src/frontend/app/layout.tsx
@@ -1,8 +1,14 @@
-import { Inter } from "next/font/google";
+import { Cormorant_Garamond, Cinzel } from "next/font/google";
 import "@styles/globals.css";
 import Head from "next/head";
 
-const inter = Inter({ subsets: ["latin"] });
+const cormorant = Cormorant_Garamond({
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
+  variable: "--font-cormorant",
+});
+
+const cinzel = Cinzel({ subsets: ["latin"], variable: "--font-cinzel" });
 
 export const metadata = {
   title: "Iglesia",
@@ -22,7 +28,7 @@ export default function RootLayout({ children }) {
         />
       </Head>
       <html lang="en">
-        <body className={inter.className}>
+        <body className={`${cormorant.className} ${cinzel.variable} font-body bg-sanctuaryLinen text-sanctuaryDeep`}>
           {children}
         </body>
       </html>

--- a/src/frontend/app/secret/page.tsx
+++ b/src/frontend/app/secret/page.tsx
@@ -41,16 +41,16 @@ const AdminLogin = () => {
 
   return (
     <form
-      className="flex flex-col items-center font-serif mb-10"
+      className="flex flex-col items-center font-body mb-10"
       onSubmit={handleLogin}
     >
-      <label className="text-3xl text-center text-slate-700 my-14">
+      <label className="text-3xl text-center text-sanctuaryBrick my-14 font-display">
         Bienvenido al Sistema de Administración
       </label>
       <BtnHome />
       <div className="flex flex-col text-center items-center border w-96 drop-shadow-lg bg-white">
         <div className="w-72 my-8">
-          <label className="text-xl">Administrador</label>
+          <label className="text-xl font-display text-sanctuaryBrick">Administrador</label>
           <div className="flex flex-col w-full mt-8 text-left gap-y-8">
             <label className="relative flex items-center">
               <UserIcon className="absolute left-3 h-5 w-5 text-slate-500" />
@@ -59,7 +59,7 @@ const AdminLogin = () => {
                 onChange={(e) => setUser(e.target.value)}
                 type="text"
                 placeholder="Usuario"
-                className="w-full rounded-sm border border-slate-300 bg-slate-200 py-2 pl-10 pr-3 text-sm text-slate-700 outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500"
+                className="w-full rounded-sm border border-slate-300 bg-slate-200 py-2 pl-10 pr-3 text-sm text-slate-700 outline-none focus:border-sanctuaryTerracotta focus:ring-1 focus:ring-sanctuaryTerracotta"
               />
             </label>
             <label className="relative flex items-center">
@@ -69,7 +69,7 @@ const AdminLogin = () => {
                 onChange={(e) => setPass(e.target.value)}
                 type="password"
                 placeholder="Contraseña"
-                className="w-full rounded-sm border border-slate-300 bg-slate-200 py-2 pl-10 pr-3 text-sm text-slate-700 outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500"
+                className="w-full rounded-sm border border-slate-300 bg-slate-200 py-2 pl-10 pr-3 text-sm text-slate-700 outline-none focus:border-sanctuaryTerracotta focus:ring-1 focus:ring-sanctuaryTerracotta"
               />
             </label>
           </div>
@@ -83,7 +83,7 @@ const AdminLogin = () => {
           <div className="flex flex-row justify-center mt-5 gap-6">
             <button
               type="submit"
-              className="flex w-full items-center justify-center gap-2 rounded-md bg-green-600 py-2 text-sm font-semibold uppercase tracking-wide text-white transition hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+              className="flex w-full items-center justify-center gap-2 rounded-md bg-sanctuaryTerracotta py-2 text-sm font-semibold uppercase tracking-wide text-white transition hover:bg-sanctuaryBrick focus:outline-none focus:ring-2 focus:ring-sanctuaryGold focus:ring-offset-2"
             >
               <ArrowRightOnRectangleIcon className="h-5 w-5" />
               Entrar

--- a/src/frontend/components/adminPage/home-carousel/homeCarousel.tsx
+++ b/src/frontend/components/adminPage/home-carousel/homeCarousel.tsx
@@ -38,7 +38,7 @@ const HomeCarousel = () => {
 
   return (
     <div className="flex flex-col justify-center items-center w-full relative">
-      <h1 className="font-serif text-3xl py-5 text-amber-800">
+      <h1 className="font-display text-3xl py-5 text-sanctuaryBrick">
         Imágenes en el Carrusel
       </h1>
       <ProgressBar progress={uploadProgress} uploading={uploading} />
@@ -70,8 +70,8 @@ const HomeCarousel = () => {
         Subir imágenes
       </button>
       <ErrorMessage error={error} />
-      <h1 className="font-serif text-2xl py-5 mt-8">Imágenes en la base de datos Carrusel</h1>
-      <div className="bg-gray-200 mt-4 mx-10 mb-10 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+      <h1 className="font-display text-2xl py-5 mt-8 text-sanctuaryBrick">Imágenes en la base de datos Carrusel</h1>
+      <div className="bg-sanctuaryCream mt-4 mx-10 mb-10 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
         {uploadedImages.map((image, index) => (
           <div key={index} className="relative h-52">
             <div className="h-40 bg-blue-400">

--- a/src/frontend/components/adminPage/recent-activity/recentActivity.tsx
+++ b/src/frontend/components/adminPage/recent-activity/recentActivity.tsx
@@ -189,7 +189,7 @@ const RecentActivity = () => {
         <ProgressBar progress={uploadProgress} uploading={uploading} />
       )}
       <div className="text-center items-center mx-auto px-4 pb-10">
-        <h1 className="font-serif text-3xl py-5 text-amber-800">
+        <h1 className="font-display text-3xl py-5 text-sanctuaryBrick">
           Actividades Recientes
         </h1>
         <button
@@ -199,7 +199,7 @@ const RecentActivity = () => {
         >
           <PlusIcon className="h-5 w-5" /> Añadir Actividad
         </button>
-        <h2 className="font-serif text-2xl py-1 mt-8">Actividades Recientes</h2>
+        <h2 className="font-display text-2xl py-1 mt-8 text-sanctuaryBrick">Actividades Recientes</h2>
       </div>
 
       {open && (
@@ -247,7 +247,7 @@ const RecentActivity = () => {
                 value={newActivity.date}
                 onChange={handleChange}
                 placeholder="Fecha"
-                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-sanctuaryTerracotta focus:outline-none focus:ring-1 focus:ring-sanctuaryTerracotta"
               />
               <input
                 type="text"
@@ -255,7 +255,7 @@ const RecentActivity = () => {
                 value={newActivity.title}
                 onChange={handleChange}
                 placeholder="Título"
-                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-sanctuaryTerracotta focus:outline-none focus:ring-1 focus:ring-sanctuaryTerracotta"
               />
               <textarea
                 name="body"
@@ -263,7 +263,7 @@ const RecentActivity = () => {
                 onChange={handleChange}
                 placeholder="Cuerpo"
                 rows={4}
-                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-sanctuaryTerracotta focus:outline-none focus:ring-1 focus:ring-sanctuaryTerracotta"
               />
               <button
                 type="button"

--- a/src/frontend/components/adminPage/workers/workers.tsx
+++ b/src/frontend/components/adminPage/workers/workers.tsx
@@ -178,7 +178,7 @@ const Workers = () => {
         <ProgressBar progress={uploadProgress} uploading={uploading} />
       )}
       <div className="text-center items-center mx-auto px-4 pb-5">
-        <h1 className="font-serif text-3xl py-5 text-amber-800">
+        <h1 className="font-display text-3xl py-5 text-sanctuaryBrick">
           Trabajadores Actuales
         </h1>
         <button
@@ -235,7 +235,7 @@ const Workers = () => {
                 value={newWorker.name}
                 onChange={handleChange}
                 placeholder="Nombre"
-                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-sanctuaryTerracotta focus:outline-none focus:ring-1 focus:ring-sanctuaryTerracotta"
               />
               <input
                 type="text"
@@ -243,7 +243,7 @@ const Workers = () => {
                 value={newWorker.rol}
                 onChange={handleChange}
                 placeholder="Rol"
-                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-sanctuaryTerracotta focus:outline-none focus:ring-1 focus:ring-sanctuaryTerracotta"
               />
               <button
                 type="button"
@@ -258,7 +258,7 @@ const Workers = () => {
         </div>
       )}
 
-      <h1 className="text-center font-serif text-2xl py-5 mt-8">
+      <h1 className="text-center font-display text-2xl py-5 mt-8 text-sanctuaryBrick">
         Trabajadores Actuales
       </h1>
       <div className="p-5" id="us">
@@ -273,8 +273,8 @@ const Workers = () => {
                 alt={`Imagen de ${worker.name}`}
                 className="rounded-full w-24 h-24 object-cover border border-gray-300 shadow-md"
               />
-              <p className="mt-4 font-semibold text-gray-800">{worker.name}</p>
-              <p className="text-sm text-gray-600">{worker.rol}</p>
+              <p className="mt-4 font-semibold text-sanctuaryDeep">{worker.name}</p>
+              <p className="text-sm text-sanctuaryBrick/80">{worker.rol}</p>
               <div className="relative bottom-52 left-2 flex space-x-2">
                 <button
                   type="button"

--- a/src/frontend/components/boxText.tsx
+++ b/src/frontend/components/boxText.tsx
@@ -15,8 +15,8 @@ const BoxText = () => {
   }
 
   return (
-    <div className="py-7 flex flex-col items-center bg-amber-50 text-amber-900">
-      <h1 className="text-3xl font-serif mb-6 text-center">
+    <div className="py-7 flex flex-col items-center bg-sanctuaryLinen text-sanctuaryDeep">
+      <h1 className="text-3xl font-display mb-6 text-center text-sanctuaryBrick">
         <Trans i18nKey="welcome">Bienvenidos a Nuestra Comunidad</Trans>
       </h1>
       <div className="w-full flex items-center lg:flex-row flex-col md:items-center justify-items-start">
@@ -29,7 +29,7 @@ const BoxText = () => {
         </div>
         <p
           ref={ref}
-          className={`font-serif text-center lg:text-left max-w-full lg:mx-20 mx-6 fade-up ${
+          className={`font-body text-center lg:text-left max-w-full lg:mx-20 mx-6 fade-up ${
             isVisible ? "visible" : ""
           }`}
         >

--- a/src/frontend/components/contactUs.tsx
+++ b/src/frontend/components/contactUs.tsx
@@ -6,13 +6,13 @@ import SocialMedia from "./socialMedia";
 const ContactUs = () => {
   return (
     <>
-      <div className="bg-amber-200 text-stone-700">
+      <div className="bg-sanctuaryCream text-sanctuaryDeep">
         <div className="text-center pt-5 pb-3">
-          <h1 className="font-roboto text-2xl text-stone-600">
+          <h1 className="font-display text-2xl text-sanctuaryBrick">
             <Trans i18nKey="contact_us">Contáctanos</Trans>
           </h1>
         </div>
-        <div className="flex flex-col md:flex-row items-center place-content-center gap-3 p-3 lg:gap-28 font-roboto">
+        <div className="flex flex-col md:flex-row items-center place-content-center gap-3 p-3 lg:gap-28 font-body">
           <div className="p-10 w-[390px] h-80" id="contact">
             <h2 className="font-semibold">
               <Trans i18nKey="hours">Horarios</Trans>:

--- a/src/frontend/components/footerApp.tsx
+++ b/src/frontend/components/footerApp.tsx
@@ -14,10 +14,10 @@ const FooterApp = () => {
   return (
     <div className="anchored-section2" id="contact">
       <ContactUs />
-      <p className="flex flex-col sm:flex-row p-3 justify-center text-center font-playfair bg-gray-800 text-white cursor-default">
+      <p className="flex flex-col sm:flex-row p-3 justify-center text-center font-display bg-sanctuaryDeep text-sanctuaryLinen cursor-default">
         <span>
           © 2024 Iglesia de San Bautista de{" "}
-          <Link className="cursor-default mr-1" href="/secret">
+          <Link className="cursor-default mr-1 text-sanctuaryGold" href="/secret">
             Remedios.
           </Link>
         </span>

--- a/src/frontend/components/langChanger.tsx
+++ b/src/frontend/components/langChanger.tsx
@@ -50,7 +50,7 @@ const LangChanger = () => {
   return (
     <div
       ref={dropdownRef}
-      className={`relative ml-2 rounded-md p-1 transition ${isOpen ? "bg-yellow-100" : ""}`}
+      className={`relative ml-2 rounded-md p-1 transition ${isOpen ? "bg-sanctuaryCream" : ""}`}
     >
       <button onClick={toggleDropdown} className="flex items-center gap-1">
         <img
@@ -59,13 +59,13 @@ const LangChanger = () => {
           className="h-6 w-6"
         />
         <ChevronUpIcon
-          className={`h-4 w-4 text-amber-900 transition-transform duration-200 ${
+          className={`h-4 w-4 text-sanctuaryBrick transition-transform duration-200 ${
             isOpen ? "rotate-180" : ""
           }`}
         />
       </button>
       {isOpen && (
-        <div className="absolute right-0 top-8 z-20 flex flex-col items-center gap-1 rounded-md bg-yellow-100 p-2 shadow-md">
+        <div className="absolute right-0 top-8 z-20 flex flex-col items-center gap-1 rounded-md bg-sanctuaryCream p-2 shadow-md">
           {flags
             .filter((flag) => flag.code !== selectedFlag.code)
             .map((flag) => (
@@ -73,7 +73,7 @@ const LangChanger = () => {
                 key={`${fileId}-${flag.code}`}
                 type="button"
                 onClick={() => handleSelectFlag(flag)}
-                className="rounded-md p-1 transition hover:bg-yellow-200"
+                className="rounded-md p-1 transition hover:bg-sanctuaryGold/20"
               >
                 <img src={flag.imgF} alt={`${flag.code} flag`} className="h-6 w-6" />
               </button>

--- a/src/frontend/components/loading.tsx
+++ b/src/frontend/components/loading.tsx
@@ -1,7 +1,7 @@
 const Loading = () => {
   return (
     <div className="flex min-h-[50vh] items-center justify-center">
-      <div className="h-12 w-12 animate-spin rounded-full border-4 border-amber-800 border-t-transparent" />
+      <div className="h-12 w-12 animate-spin rounded-full border-4 border-sanctuaryTerracotta border-t-transparent" />
     </div>
   );
 };

--- a/src/frontend/components/navMobile.tsx
+++ b/src/frontend/components/navMobile.tsx
@@ -25,13 +25,13 @@ function NavMobile({ isMobile }) {
   return (
     <>
       <header
-        className={`fixed top-0 z-50 w-full bg-white transition-shadow duration-300 ${
+        className={`fixed top-0 z-50 w-full bg-white/95 backdrop-blur transition-shadow duration-300 ${
           scrolled ? "shadow-md" : "shadow-none"
         }`}
       >
         <div className="flex items-center justify-between px-4 py-3">
           <Link href="/">
-            <h1 className="text-amber-900 font-playfair text-lg">
+            <h1 className="text-sanctuaryBrick font-display text-lg">
               San Juan Bautista de Remedios
             </h1>
           </Link>
@@ -41,7 +41,7 @@ function NavMobile({ isMobile }) {
               type="button"
               onClick={toggleDrawer}
               aria-label="Abrir menú"
-              className="rounded-md p-2 text-amber-900 transition hover:bg-amber-100"
+              className="rounded-md p-2 text-sanctuaryBrick transition hover:bg-sanctuaryCream"
             >
               <Bars3Icon className="h-7 w-7" />
             </button>
@@ -56,12 +56,12 @@ function NavMobile({ isMobile }) {
             onClick={closeDrawer}
             aria-hidden="true"
           />
-          <aside className="relative ml-auto flex h-full w-64 flex-col bg-white p-4 shadow-lg transition-transform">
+          <aside className="relative ml-auto flex h-full w-64 flex-col bg-sanctuaryLinen/95 p-4 shadow-lg transition-transform">
             <button
               type="button"
               onClick={closeDrawer}
               aria-label="Cerrar menú"
-              className="self-end rounded-md p-2 text-amber-900 transition hover:bg-amber-100"
+              className="self-end rounded-md p-2 text-sanctuaryBrick transition hover:bg-sanctuaryCream"
             >
               <XMarkIcon className="h-6 w-6" />
             </button>

--- a/src/frontend/components/navPC.tsx
+++ b/src/frontend/components/navPC.tsx
@@ -21,13 +21,13 @@ function NavPC({ isMobile }) {
   return (
     <>
       <header
-        className={`fixed top-0 z-50 w-full bg-white transition-shadow duration-300 ${
+        className={`fixed top-0 z-50 w-full bg-white/95 backdrop-blur transition-shadow duration-300 ${
           scrolled ? "shadow-md" : "shadow-none"
         }`}
       >
         <div className="mx-auto flex max-w-6xl items-center px-4 py-3 md:px-8">
           <Link href="/">
-            <h1 className="text-amber-900 font-playfair text-lg sm:text-xl md:text-2xl">
+            <h1 className="text-sanctuaryBrick font-display text-lg sm:text-xl md:text-2xl">
               San Juan Bautista de Remedios
             </h1>
           </Link>

--- a/src/frontend/components/navText.tsx
+++ b/src/frontend/components/navText.tsx
@@ -18,7 +18,7 @@ const NavText = ({ isMobile }) => {
           <div className={`${isMobile ? 'px-2' : 'mb-5'}`} key={index}>
             <Link
               href={item.link}
-              className="text-amber-800 hover:text-yellow-500 transition-colors duration-300 text-lg font-playfair tracking-wider"
+              className="text-sanctuaryBrick hover:text-sanctuaryGold transition-colors duration-300 text-lg font-display tracking-wider"
             >
               {t(`navigation.${item.key}`)}
             </Link>

--- a/src/frontend/components/navTextMobile.tsx
+++ b/src/frontend/components/navTextMobile.tsx
@@ -10,7 +10,7 @@ const NavTextMobile = ({ items }) => {
           <div key={index}>
             <Link
               href={item.link}
-              className="text-amber-800 hover:text-yellow-500 transition-colors duration-300 text-lg font-playfair tracking-wider px-2"
+              className="text-sanctuaryBrick hover:text-sanctuaryGold transition-colors duration-300 text-lg font-display tracking-wider px-2"
             >
               {item.text}
             </Link>

--- a/src/frontend/components/noticias/cards.tsx
+++ b/src/frontend/components/noticias/cards.tsx
@@ -17,7 +17,7 @@ const Cards = ({ title, text, imageUrl, date, itemKey }) => {
         onClick={toggleDialog}
         key={itemKey}
       >
-        <div className="flex flex-col rounded-xl font-merriweather">
+        <div className="flex flex-col rounded-xl font-body">
           <div className="flex justify-center">
             <img
               src={imageUrl}
@@ -25,12 +25,12 @@ const Cards = ({ title, text, imageUrl, date, itemKey }) => {
               alt=""
             />
           </div>
-          <div className="flex flex-col p-4 gap-y-1 text-gray-500 ">
+          <div className="flex flex-col p-4 gap-y-1 text-sanctuaryDeep/80 ">
             <div className="flex items-center gap-2 ">
-              <CalendarDaysIcon className="h-4 w-4 text-amber-700" />
+              <CalendarDaysIcon className="h-4 w-4 text-sanctuaryTerracotta" />
               <p className="text-xs">{date}</p>
             </div>
-            <h1 className="text-base text-black font-semibold">{title}</h1>
+            <h1 className="text-base text-sanctuaryBrick font-semibold font-display">{title}</h1>
             <p className="text-sm overflow-hidden h-16 text-ellipsis line-clamp-3">{text}</p>
           </div>
         </div>

--- a/src/frontend/components/noticias/dialog.tsx
+++ b/src/frontend/components/noticias/dialog.tsx
@@ -26,7 +26,7 @@ function DialogCard({ open, handleClose, title, date, text, imageUrl }: DialogCa
           <img src={imageUrl} alt={title} className="h-full w-full object-cover" />
         </div>
         <div className="flex w-full flex-col gap-3 px-6 py-4 text-center">
-          <h2 id="dialog-title" className="font-serif text-xl text-gray-900">
+          <h2 id="dialog-title" className="font-display text-xl text-sanctuaryBrick">
             {title}
           </h2>
           <p className="text-sm text-gray-600">{date}</p>
@@ -34,7 +34,7 @@ function DialogCard({ open, handleClose, title, date, text, imageUrl }: DialogCa
           <div className="mt-4 flex justify-end">
             <button
               onClick={handleClose}
-              className="rounded-md bg-amber-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
+              className="rounded-md bg-sanctuaryTerracotta px-4 py-2 text-sm font-semibold text-white transition hover:bg-sanctuaryBrick focus:outline-none focus:ring-2 focus:ring-sanctuaryGold focus:ring-offset-2"
             >
               Cerrar
             </button>

--- a/src/frontend/components/noticias/noticias.tsx
+++ b/src/frontend/components/noticias/noticias.tsx
@@ -24,8 +24,8 @@ const Noticias = () => {
   }, []);
 
   return (
-    <div className="mx-auto px-4 bg-yellow-200 pb-10">
-      <h1 className="text-center font-serif text-3xl py-10 text-amber-800">{t(`Actividades Recientes`)}</h1>
+    <div className="mx-auto px-4 bg-sanctuaryCream pb-10">
+      <h1 className="text-center font-display text-3xl py-10 text-sanctuaryBrick">{t(`Actividades Recientes`)}</h1>
       <div className="cardsok">
         {notices.map((n, index) => (
           <Cards key={index} itemKey={index} title={n.title} text={n.body} imageUrl={`data:image/jpeg;base64,${n.image}`} date={n.date}/>

--- a/src/frontend/components/services.tsx
+++ b/src/frontend/components/services.tsx
@@ -35,12 +35,16 @@ function Services() {
   const selectServices = servicios.find((servicio) => servicio.id === value);
 
   return (
-    <div className="font-roboto bg-amber-50 anchored-section2" id="services">
-      <h1 className="text-center py-6 text-2xl">{t(`Servicios`)}</h1>
+    <div className="font-body bg-sanctuaryLinen anchored-section2" id="services">
+      <h1 className="text-center py-6 text-2xl font-display text-sanctuaryBrick">{t(`Servicios`)}</h1>
       <div className="flex justify-between h-14 w-full">
         <div className="flex justify-center items-center h-full w-1/3">
           <button
-            className={`h-full w-full text-white  ${value === 1 ? 'bg-amber-950 opacity-80' : 'bg-amber-950 hover:bg-950 hover:opacity-60'}`}
+            className={`h-full w-full text-white transition ${
+              value === 1
+                ? "bg-sanctuaryBrick/90"
+                : "bg-sanctuaryTerracotta hover:bg-sanctuaryBrick/80"
+            }`}
             onClick={() => handleChange(1)}
             disabled={value === 1}
           >
@@ -49,7 +53,11 @@ function Services() {
         </div>
         <div className="flex justify-center items-center h-full w-1/3">
           <button
-            className={`h-full w-full text-white  ${value === 2 ? 'bg-amber-950 opacity-80' : 'bg-amber-950 hover:bg-950 hover:opacity-60'}`}
+            className={`h-full w-full text-white transition ${
+              value === 2
+                ? "bg-sanctuaryBrick/90"
+                : "bg-sanctuaryTerracotta hover:bg-sanctuaryBrick/80"
+            }`}
             onClick={() => handleChange(2)}
             disabled={value === 2}
           >
@@ -58,7 +66,11 @@ function Services() {
         </div>
         <div className="flex justify-center items-center h-full w-1/3">
           <button
-            className={`h-full w-full text-white  ${value === 3 ? 'bg-amber-950 opacity-80' : 'bg-amber-950 hover:bg-950 hover:opacity-60'}`}
+            className={`h-full w-full text-white transition ${
+              value === 3
+                ? "bg-sanctuaryBrick/90"
+                : "bg-sanctuaryTerracotta hover:bg-sanctuaryBrick/80"
+            }`}
             onClick={() => handleChange(3)}
             disabled={value === 3}
           >
@@ -66,7 +78,7 @@ function Services() {
           </button>
         </div>
       </div>
-      <div className="flex mx-10 py-10 items-center justify-center text-black text-md">
+      <div className="flex mx-10 py-10 items-center justify-center text-md text-sanctuaryDeep">
         {selectServices.descripcion}
       </div>
     </div>

--- a/src/frontend/components/socialMedia.tsx
+++ b/src/frontend/components/socialMedia.tsx
@@ -24,14 +24,14 @@ const YouTubeIcon = () => (
 
 const SocialMedia = () => {
   return (
-    <div className="flex gap-3 mt-1">
-      <Link href="asd" aria-label="Instagram" className="text-rose-500 transition hover:text-rose-600">
+    <div className="flex gap-3 mt-1 text-sanctuaryTerracotta">
+      <Link href="asd" aria-label="Instagram" className="transition hover:text-sanctuaryBrick">
         <InstagramIcon />
       </Link>
-      <Link href="sdf" aria-label="Facebook" className="text-blue-600 transition hover:text-blue-700">
+      <Link href="sdf" aria-label="Facebook" className="transition hover:text-sanctuaryBrick">
         <FacebookIcon />
       </Link>
-      <Link href="ad" aria-label="YouTube" className="text-red-600 transition hover:text-red-700">
+      <Link href="ad" aria-label="YouTube" className="transition hover:text-sanctuaryBrick">
         <YouTubeIcon />
       </Link>
     </div>

--- a/src/frontend/components/weAre.tsx
+++ b/src/frontend/components/weAre.tsx
@@ -25,8 +25,8 @@ const ImageCircle = () => {
   }, []);
 
   return (
-    <div className="bg-amber-100 p-5 anchored-section" id="us">
-      <h2 className="text-3xl mb-8 text-center font-serif text-gray-600">{t('Nuestro Equipo')}</h2>
+    <div className="bg-sanctuaryLinen p-5 anchored-section" id="us">
+      <h2 className="text-3xl mb-8 text-center font-display text-sanctuaryBrick">{t('Nuestro Equipo')}</h2>
       <div className="flex flex-wrap justify-center gap-8">
         {teamMembers.map((member, index) => (
           <div key={index} className="flex flex-col items-center text-center">
@@ -35,8 +35,8 @@ const ImageCircle = () => {
               alt={`Imagen de ${member.name}`}
               className="rounded-full w-24 h-24 object-cover border border-gray-300 shadow-md"
             />
-            <p className="mt-4 font-semibold text-gray-800">{member.name}</p>
-            <p className="text-sm text-gray-600">{member.rol}</p>
+            <p className="mt-4 font-semibold text-sanctuaryDeep">{member.name}</p>
+            <p className="text-sm text-sanctuaryBrick/80">{member.rol}</p>
           </div>
         ))}
       </div>

--- a/src/frontend/styles/globals.css
+++ b/src/frontend/styles/globals.css
@@ -18,7 +18,7 @@
 }
 
 .iconClose {
-  color: #5c4506; /* Este es el valor de text-amber-900 en Tailwind CSS */
+  color: #93412c;
 }
 
 html {
@@ -31,18 +31,18 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: #bb6b2f;
+  background-color: #c65b3a;
   border-radius: 4px; /* Bordes redondeados */
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #374151; /* Ajustado para coincidir con gray-700 de Tailwind */
+  background: #93412c;
 }
 
 /* Estilos para Firefox */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #c87f47 #ebceb4; /* Color amber-800 para el "pulgar" y transparente para la "pista" */
+  scrollbar-color: #c65b3a #f4d8a8;
 }
 
 /* Añade transiciones para suavizar la aparición del dropdown */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,15 +11,17 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        merriweather: ["Merriweather", "serif"],
-        playfair: ["Playfair Display", "serif"],
-        roboto: ["Roboto", "sans-serif"],
+        body: ["var(--font-cormorant)", "serif"],
+        display: ["var(--font-cinzel)", "serif"],
       },
       colors: {
-        customYellow: '#fad390',
-        customOrange:'#fcb07e',
-        customBlue:"#3581b8",
-        customGray:'#dee2d6'
+        sanctuaryLinen: "#fdf2e3",
+        sanctuaryCream: "#f4d8a8",
+        sanctuaryGold: "#d7ad62",
+        sanctuaryTerracotta: "#c65b3a",
+        sanctuaryBrick: "#93412c",
+        sanctuaryDeep: "#513526",
+        sanctuarySky: "#88a2c0",
       },
     },
   },


### PR DESCRIPTION
## Summary
- introduce a warm terracotta-and-cream palette and classical serif typography through the Tailwind theme and global layout
- refresh navigation, content sections, and social elements to adopt the new colors and display type for a cohesive church-inspired look
- align donation and admin forms with the updated palette, adjusting button, focus, and heading styles

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cfca730bbc832ca15372cdbeee3959