### PR TITLE
Refactor public site into separate dynamic sections

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,24 +1,72 @@
 {
-	"navigation": {
-		"us": "Us",
-		"services": "Services",
-		"contact": "Contact",
-		"donations": "Donate"
-	},
-	"welcome": "Welcome to Our Community",
-	"image_description": "Image Description",
-	"description": "The Church of San Juan Bautista de Remedios located in San Juan de los Remedios, Villa Clara is considered the oldest church in Cuba. The current church was built in 1692 on the existing structure of a church that was originally built in 1570. The bell tower is a neoclassical design and the interior is baroque. Some of the most important features are the ornate ceiling, the gold leaf, and the cedar altar all carved in wood and laminated in gold by a Remedios artisan of Asian descent Rogelio Attá and places baroque altarpieces and pictorial collection in both naves of the church. It is today the only baroque church interior and exteriorly in Cuba being permanently visited by national and international tourism who come to appreciate its preserved patrimonial assets.",
-	"Actividades Recientes": "Recent Activities",
-	"Servicios": "Services",
-	"Nuestro Equipo": "Our Team",
-	"contact_us": "Contact Us",
-	"hours": "Hours",
-	"weekdays": "Monday to Friday",
-	"saturday": "Saturday",
-	"sunday": "Sunday",
-	"info": "Info",
-	"phone": "Phone",
-	"email": "Email",
-    "Todos los derechos reservados.": "All rights reserved."
-  
+  "navigation": {
+    "us": "About us",
+    "services": "Services",
+    "contact": "Contact",
+    "donations": "Donate"
+  },
+  "hero": {
+    "slides": [
+      {
+        "title": "Faith that inspires",
+        "description": "Celebrate with us the tradition of San Juan Bautista de Remedios."
+      },
+      {
+        "title": "A united community",
+        "description": "Join our activities and share meaningful moments."
+      },
+      {
+        "title": "Living heritage",
+        "description": "Experience the architectural and spiritual beauty of our parish."
+      }
+    ]
+  },
+  "sections": {
+    "about": {
+      "title": "Our history",
+      "subtitle": "Get to know the community that has accompanied Remedios for generations."
+    },
+    "services": {
+      "title": "Pastoral services",
+      "subtitle": "We guide you through every sacrament and important celebration.",
+      "intro": "Our team walks beside you with warm, faith-filled ceremonies for every stage of life."
+    },
+    "contact": {
+      "title": "We are here for you",
+      "subtitle": "Reach out to us and receive personalized guidance.",
+      "intro": "Write, call or visit us. You will always find a friendly hand ready to help."
+    }
+  },
+  "services": {
+    "heading": "Our services",
+    "items": {
+      "baptism": {
+        "title": "Baptism",
+        "description": "Baptism is a sacred celebration. We help you prepare every detail so that the welcome into faith is warm and meaningful."
+      },
+      "wedding": {
+        "title": "Wedding",
+        "description": "Your wedding deserves to be unforgettable. We organize a ceremony that reflects your love story and your family values."
+      },
+      "community": {
+        "title": "Community support",
+        "description": "We provide spiritual support and pastoral activities that strengthen the bonds within our community."
+      }
+    }
+  },
+  "welcome": "Welcome to Our Community",
+  "image_description": "Image Description",
+  "description": "The Church of San Juan Bautista de Remedios located in San Juan de los Remedios, Villa Clara is considered the oldest church in Cuba. The current church was built in 1692 on the existing structure of a church that was originally built in 1570. The bell tower is a neoclassical design and the interior is baroque. Some of the most important features are the ornate ceiling, the gold leaf, and the cedar altar all carved in wood and laminated in gold by a Remedios artisan of Asian descent Rogelio Attá and places baroque altarpieces and pictorial collection in both naves of the church. It is today the only baroque church interior and exteriorly in Cuba being permanently visited by national and international tourism who come to appreciate its preserved patrimonial assets.",
+  "Actividades Recientes": "Recent Activities",
+  "Servicios": "Services",
+  "Nuestro Equipo": "Our Team",
+  "contact_us": "Contact Us",
+  "hours": "Hours",
+  "weekdays": "Monday to Friday",
+  "saturday": "Saturday",
+  "sunday": "Sunday",
+  "info": "Info",
+  "phone": "Phone",
+  "email": "Email",
+  "Todos los derechos reservados.": "All rights reserved."
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,24 +1,72 @@
 {
-	"navigation": {
-		"us": "Nosotros",
-		"services": "Servicios",
-		"contact": "Contacto",
-		"donations": "Donar"
-	},
-	"welcome": "Bienvenidos a Nuestra Comunidad",
-	"image_description": "Descripción de la imagen",
-	"description": "La Iglesia de San Juan Bautista de Remedios ubicada en San Juan de los Remedios, Villa Clara se le atribuye ser la iglesia más antigua de Cuba. La iglesia actual fue construida en 1692 sobre la estructura existente de una iglesia que fue construida originalmente en 1570. La torre-campanario es un diseño neoclásico y el interior es barroco. Algunas de las características más importantes son el techo ornamentado, el pan de oro y el altar de cedro cubierto todo tallado en madera y laminado en oro realizado por un artesano remediano de descendencia asiática Rogelio Attá y coloca retablos barrocos y colección pictórica en ambas naves de la iglesia. Es hoy la única iglesia barroca interior y exteriormente en Cuba siendo visitada permanentemente por turismo nacional e internacional que acuden a apreciar sus bienes conservados patrimoniales.",
-	"Actividades Recientes": "Actividades Recientes",
-	"Servicios": "Servicios",
-	"Nuestro Equipo": "Nuestro Equipo",
-	"contact_us": "Contáctanos",
-	"hours": "Horarios",
-	"weekdays": "Lunes a Viernes",
-	"saturday": "Sábados",
-	"sunday": "Domingos",
-	"info": "Info",
-	"phone": "Teléfono",
-	"email": "Correo",
-    "Todos los derechos reservados.": "Todos los derechos reservados."
-  
+  "navigation": {
+    "us": "Nosotros",
+    "services": "Servicios",
+    "contact": "Contacto",
+    "donations": "Donar"
+  },
+  "hero": {
+    "slides": [
+      {
+        "title": "Fe que inspira",
+        "description": "Celebra con nosotros la tradición de San Juan Bautista de Remedios."
+      },
+      {
+        "title": "Una comunidad unida",
+        "description": "Participa en nuestras actividades y comparte momentos significativos."
+      },
+      {
+        "title": "Patrimonio vivo",
+        "description": "Descubre la belleza arquitectónica y espiritual de nuestra parroquia."
+      }
+    ]
+  },
+  "sections": {
+    "about": {
+      "title": "Nuestra historia",
+      "subtitle": "Conoce la comunidad que ha acompañado a Remedios por generaciones."
+    },
+    "services": {
+      "title": "Servicios pastorales",
+      "subtitle": "Te guiamos en cada sacramento y celebración importante.",
+      "intro": "Nuestro equipo está preparado para acompañarte en cada etapa de la vida con ceremonias personalizadas y llenas de fe."
+    },
+    "contact": {
+      "title": "Estamos para escucharte",
+      "subtitle": "Comunícate con nosotros y recibe orientación personalizada.",
+      "intro": "Puedes escribirnos, llamarnos o visitarnos. Siempre encontrarás una mano amiga dispuesta a ayudarte."
+    }
+  },
+  "services": {
+    "heading": "Nuestros servicios",
+    "items": {
+      "baptism": {
+        "title": "Bautismo",
+        "description": "La ceremonia de bautismo es un momento sagrado. Te ayudamos a preparar cada detalle para que la bienvenida a la fe sea cálida y significativa."
+      },
+      "wedding": {
+        "title": "Boda",
+        "description": "Tu celebración nupcial merece ser inolvidable. Organizamos una ceremonia que refleje su historia de amor y los valores de su familia."
+      },
+      "community": {
+        "title": "Acompañamiento comunitario",
+        "description": "Ofrecemos apoyo espiritual y actividades pastorales para fortalecer la vida de la comunidad y sus vínculos fraternos."
+      }
+    }
+  },
+  "welcome": "Bienvenidos a Nuestra Comunidad",
+  "image_description": "Descripción de la imagen",
+  "description": "La Iglesia de San Juan Bautista de Remedios ubicada en San Juan de los Remedios, Villa Clara se le atribuye ser la iglesia más antigua de Cuba. La iglesia actual fue construida en 1692 sobre la estructura existente de una iglesia que fue construida originalmente en 1570. La torre-campanario es un diseño neoclásico y el interior es barroco. Algunas de las características más importantes son el techo ornamentado, el pan de oro y el altar de cedro cubierto todo tallado en madera y laminado en oro realizado por un artesano remediano de descendencia asiática Rogelio Attá y coloca retablos barrocos y colección pictórica en ambas naves de la iglesia. Es hoy la única iglesia barroca interior y exteriormente en Cuba siendo visitada permanentemente por turismo nacional e internacional que acuden a apreciar sus bienes conservados patrimoniales.",
+  "Actividades Recientes": "Actividades Recientes",
+  "Servicios": "Servicios",
+  "Nuestro Equipo": "Nuestro Equipo",
+  "contact_us": "Contáctanos",
+  "hours": "Horarios",
+  "weekdays": "Lunes a Viernes",
+  "saturday": "Sábados",
+  "sunday": "Domingos",
+  "info": "Info",
+  "phone": "Teléfono",
+  "email": "Correo",
+  "Todos los derechos reservados.": "Todos los derechos reservados."
 }

--- a/public/locales/po/translation.json
+++ b/public/locales/po/translation.json
@@ -1,24 +1,72 @@
 {
-	"navigation": {
-		"us": "O nas",
-		"services": "Usługi",
-		"contact": "Kontakt",
-		"donations": "Darowizny"
-	},
-	"welcome": "Witamy w naszej społeczności",
-	"image_description": "Opis obrazu",
-	"description": "Kościół San Juan Bautista de Remedios położony w San Juan de los Remedios, Villa Clara uważany jest za najstarszy kościół na Kubie. Obecny kościół został zbudowany w 1692 roku na istniejącej strukturze kościoła, który został pierwotnie zbudowany w 1570 roku. Wieża-dzwonnica ma neoklasyczny styl, a wnętrze jest barokowe. Niektóre z najważniejszych cech to ozdobny sufit, złote liście i ołtarz z cedru, wszystkie rzeźbione w drewnie i pokryte złotem przez rzemieślnika z Remedios pochodzenia azjatyckiego Rogelio Attá, który umieszcza barokowe ołtarze i kolekcję obrazów w obu nawach kościoła. Jest to dzisiaj jedyny barokowy kościół wewnętrznie i zewnętrznie na Kubie, który jest stale odwiedzany przez krajowych i międzynarodowych turystów, którzy przyjeżdżają, aby docenić jego zachowane zabytkowe dobra.",
-	"Actividades Recientes": "Najnowsze Działania",
-	"Servicios": "Usługi",
-	"Nuestro Equipo": "Nasz Zespół",
-	"contact_us": "Skontaktuj się z nami",
-	"hours": "Godziny",
-	"weekdays": "Poniedziałek do piątku",
-	"saturday": "Sobota",
-	"sunday": "Niedziela",
-	"info": "Informacje",
-	"phone": "Telefon",
-	"email": "E-mail",
-    "Todos los derechos reservados.": "Wszelkie prawa zastrzeżone."
-  
+  "navigation": {
+    "us": "O nas",
+    "services": "Usługi",
+    "contact": "Kontakt",
+    "donations": "Darowizny"
+  },
+  "hero": {
+    "slides": [
+      {
+        "title": "Wiara, która inspiruje",
+        "description": "Świętuj z nami tradycję San Juan Bautista de Remedios."
+      },
+      {
+        "title": "Zjednoczona wspólnota",
+        "description": "Dołącz do naszych aktywności i dziel się wyjątkowymi chwilami."
+      },
+      {
+        "title": "Żywe dziedzictwo",
+        "description": "Odkryj architektoniczne i duchowe piękno naszej parafii."
+      }
+    ]
+  },
+  "sections": {
+    "about": {
+      "title": "Nasza historia",
+      "subtitle": "Poznaj wspólnotę, która towarzyszy Remedios od pokoleń."
+    },
+    "services": {
+      "title": "Posługa duszpasterska",
+      "subtitle": "Prowadzimy cię przez każdy sakrament i ważną uroczystość.",
+      "intro": "Nasz zespół towarzyszy ci na każdym etapie życia, organizując uroczystości pełne wiary i ciepła."
+    },
+    "contact": {
+      "title": "Jesteśmy tu dla ciebie",
+      "subtitle": "Skontaktuj się z nami i otrzymaj indywidualne wsparcie.",
+      "intro": "Napisz, zadzwoń lub odwiedź nas. Zawsze znajdziesz życzliwą dłoń gotową do pomocy."
+    }
+  },
+  "services": {
+    "heading": "Nasze usługi",
+    "items": {
+      "baptism": {
+        "title": "Chrzest",
+        "description": "Uroczystość chrztu to święty moment. Pomożemy ci przygotować każdy szczegół, aby powitanie w wierze było ciepłe i wyjątkowe."
+      },
+      "wedding": {
+        "title": "Ślub",
+        "description": "Twoja ceremonia ślubna powinna być niezapomniana. Organizujemy uroczystość, która odzwierciedla waszą historię miłości i rodzinne wartości."
+      },
+      "community": {
+        "title": "Wsparcie wspólnoty",
+        "description": "Zapewniamy duchowe wsparcie i działania duszpasterskie, które wzmacniają więzi w naszej wspólnocie."
+      }
+    }
+  },
+  "welcome": "Witamy w naszej społeczności",
+  "image_description": "Opis obrazu",
+  "description": "Kościół San Juan Bautista de Remedios położony w San Juan de los Remedios, Villa Clara uważany jest za najstarszy kościół na Kubie. Obecny kościół został zbudowany w 1692 roku na istniejącej strukturze kościoła, który został pierwotnie zbudowany w 1570 roku. Wieża-dzwonnica ma neoklasyczny styl, a wnętrze jest barokowe. Niektóre z najważniejszych cech to ozdobny sufit, złote liście i ołtarz z cedru, wszystkie rzeźbione w drewnie i pokryte złotem przez rzemieślnika z Remedios pochodzenia azjatyckiego Rogelio Attá, który umieszcza barokowe ołtarze i kolekcję obrazów w obu nawach kościoła. Jest to dzisiaj jedyny barokowy kościół wewnętrznie i zewnętrznie na Kubie, który jest stale odwiedzany przez krajowych i międzynarodowych turystów, którzy przyjeżdżają, aby docenić jego zachowane zabytkowe dobra.",
+  "Actividades Recientes": "Najnowsze Działania",
+  "Servicios": "Usługi",
+  "Nuestro Equipo": "Nasz Zespół",
+  "contact_us": "Skontaktuj się z nami",
+  "hours": "Godziny",
+  "weekdays": "Poniedziałek do piątku",
+  "saturday": "Sobota",
+  "sunday": "Niedziela",
+  "info": "Informacje",
+  "phone": "Telefon",
+  "email": "E-mail",
+  "Todos los derechos reservados.": "Wszelkie prawa zastrzeżone."
 }

--- a/src/frontend/app/contacto/page.tsx
+++ b/src/frontend/app/contacto/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import ContactUs from "@components/contactUs";
+import Loading from "@components/loading";
+import PageShell from "@components/pageShell";
+import SectionHero from "@components/sectionHero";
+import useIntersectionObserver from "@hooks/useIntersectionObserver";
+import { useTranslation } from "react-i18next";
+import "../../i18next.config";
+
+const CONTACT_IMAGE =
+  "https://images.unsplash.com/photo-1529753256307-1c3c9cbe26ff?auto=format&fit=crop&w=1400&q=80";
+
+const ContactoPage = () => {
+  const { t, i18n } = useTranslation();
+  const [ref, isVisible] = useIntersectionObserver({ threshold: 0.2 });
+
+  if (!i18n.isInitialized) {
+    return <Loading />;
+  }
+
+  return (
+    <PageShell showContactInFooter={false}>
+      <SectionHero
+        imageUrl={CONTACT_IMAGE}
+        title={t("sections.contact.title")}
+        description={t("sections.contact.subtitle")}
+      />
+      <section className="bg-sanctuaryLinen py-12">
+        <div className="mx-auto max-w-3xl px-6 text-center text-sanctuaryDeep md:text-left">
+          <p
+            ref={ref}
+            className={`font-body text-base transition-all duration-700 ease-out md:text-lg ${
+              isVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+            }`}
+          >
+            {t("sections.contact.intro")}
+          </p>
+        </div>
+      </section>
+      <ContactUs />
+    </PageShell>
+  );
+};
+
+export default ContactoPage;

--- a/src/frontend/app/nosotros/page.tsx
+++ b/src/frontend/app/nosotros/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import BoxText from "@components/boxText";
+import ImageCircle from "@components/weAre";
+import Loading from "@components/loading";
+import PageShell from "@components/pageShell";
+import SectionHero from "@components/sectionHero";
+import { useTranslation } from "react-i18next";
+import "../../i18next.config";
+
+const ABOUT_IMAGE =
+  "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=80";
+const ABOUT_SECTION_IMAGE =
+  "https://images.unsplash.com/photo-1467307983825-619715426c48?auto=format&fit=crop&w=1200&q=80";
+
+const NosotrosPage = () => {
+  const { t, i18n } = useTranslation();
+
+  if (!i18n.isInitialized) {
+    return <Loading />;
+  }
+
+  return (
+    <PageShell>
+      <SectionHero
+        imageUrl={ABOUT_IMAGE}
+        title={t("sections.about.title")}
+        description={t("sections.about.subtitle")}
+      />
+      <BoxText imageUrl={ABOUT_SECTION_IMAGE} />
+      <ImageCircle />
+    </PageShell>
+  );
+};
+
+export default NosotrosPage;

--- a/src/frontend/app/page.tsx
+++ b/src/frontend/app/page.tsx
@@ -1,37 +1,45 @@
 "use client";
-import { Suspense } from "react";
-import BoxText from "@components/boxText";
-import Nav from "@components/nav";
-import Services from "@components/services";
-import FooterApp from "@components/footerApp";
-import Carrousel from "@components/carrousel";
-import Noticias from "@components/noticias/noticias";
-import ImageCircle from "@components/weAre";
+
+import Link from "next/link";
 import { useTranslation } from "react-i18next";
+import useIntersectionObserver from "@hooks/useIntersectionObserver";
+import PageShell from "@components/pageShell";
+import HomeHero from "@components/homeHero";
+import Noticias from "@components/noticias/noticias";
+import Loading from "@components/loading";
 import "../i18next.config";
 
 export default function Home() {
   const { t, i18n } = useTranslation();
+  const [ref, isVisible] = useIntersectionObserver({ threshold: 0.2 });
 
   if (!i18n.isInitialized) {
-    return <div>Loading...</div>;
+    return <Loading />;
   }
 
   return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <Nav />
-      <Carrousel />
-      <aside>
-        <BoxText />
-        <Noticias />
-      </aside>
-      <section>
-        <Services />
+    <PageShell>
+      <HomeHero />
+      <section className="bg-sanctuaryLinen py-12">
+        <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 px-6 text-center md:items-start md:text-left">
+          <h2 className="text-3xl font-display text-sanctuaryBrick sm:text-4xl">{t("welcome")}</h2>
+          <p
+            ref={ref}
+            className={`font-body text-base text-sanctuaryDeep transition-all duration-700 ease-out md:text-lg ${
+              isVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+            }`}
+          >
+            {t("sections.about.subtitle")}
+          </p>
+          <Link
+            href="/nosotros"
+            className="rounded-full bg-sanctuaryBrick px-6 py-3 font-display text-sm uppercase tracking-widest text-sanctuaryLinen shadow-md transition hover:bg-sanctuaryTerracotta"
+          >
+            {t("navigation.us")}
+          </Link>
+        </div>
       </section>
-      <footer>
-      <ImageCircle />
-        <FooterApp />
-      </footer>
-    </Suspense>
+      <Noticias />
+    </PageShell>
   );
 }

--- a/src/frontend/app/servicios/page.tsx
+++ b/src/frontend/app/servicios/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Services from "@components/services";
+import Loading from "@components/loading";
+import PageShell from "@components/pageShell";
+import SectionHero from "@components/sectionHero";
+import useIntersectionObserver from "@hooks/useIntersectionObserver";
+import { useTranslation } from "react-i18next";
+import "../../i18next.config";
+
+const SERVICES_IMAGE =
+  "https://images.unsplash.com/photo-1491884662610-dfcd28f30cf5?auto=format&fit=crop&w=1400&q=80";
+
+const ServiciosPage = () => {
+  const { t, i18n } = useTranslation();
+  const [ref, isVisible] = useIntersectionObserver({ threshold: 0.2 });
+
+  if (!i18n.isInitialized) {
+    return <Loading />;
+  }
+
+  return (
+    <PageShell>
+      <SectionHero
+        imageUrl={SERVICES_IMAGE}
+        title={t("sections.services.title")}
+        description={t("sections.services.subtitle")}
+      />
+      <section className="bg-sanctuaryLinen py-12">
+        <div className="mx-auto max-w-3xl px-6 text-center text-sanctuaryDeep md:text-left">
+          <p
+            ref={ref}
+            className={`font-body text-base transition-all duration-700 ease-out md:text-lg ${
+              isVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+            }`}
+          >
+            {t("sections.services.intro")}
+          </p>
+        </div>
+      </section>
+      <Services />
+    </PageShell>
+  );
+};
+
+export default ServiciosPage;

--- a/src/frontend/components/boxText.tsx
+++ b/src/frontend/components/boxText.tsx
@@ -3,8 +3,20 @@ import { useTranslation, Trans } from "react-i18next";
 import useIntersectionObserver from "@hooks/useIntersectionObserver";
 import Loading from "./loading";
 
-const BoxText = () => {
-  const {  i18n } = useTranslation();
+type BoxTextProps = {
+  imageUrl?: string;
+  imageAltKey?: string;
+  titleKey?: string;
+  descriptionKey?: string;
+};
+
+const BoxText = ({
+  imageUrl = "/images/img1.jpg",
+  imageAltKey = "image_description",
+  titleKey = "welcome",
+  descriptionKey = "description",
+}: BoxTextProps) => {
+  const { t, i18n } = useTranslation();
   const [ref, isVisible] = useIntersectionObserver({
     threshold: 0.1,
   });
@@ -17,13 +29,13 @@ const BoxText = () => {
   return (
     <div className="py-7 flex flex-col items-center bg-sanctuaryLinen text-sanctuaryDeep">
       <h1 className="text-3xl font-display mb-6 text-center text-sanctuaryBrick">
-        <Trans i18nKey="welcome">Bienvenidos a Nuestra Comunidad</Trans>
+        <Trans i18nKey={titleKey}>Bienvenidos a Nuestra Comunidad</Trans>
       </h1>
       <div className="w-full flex items-center lg:flex-row flex-col md:items-center justify-items-start">
         <div className="flex-shrink-0 h-96 lg:w-96 sm:w-[500px] w-full mb-4">
           <img
-            src="/images/img1.jpg"
-            alt={"image_description"}
+            src={imageUrl}
+            alt={t(imageAltKey)}
             className="w-full h-full object-cover lg:rounded-r-full rounded-sm"
           />
         </div>
@@ -33,7 +45,7 @@ const BoxText = () => {
             isVisible ? "visible" : ""
           }`}
         >
-          <Trans i18nKey="description">
+          <Trans i18nKey={descriptionKey}>
             La Iglesia de San Juan Bautista de Remedios ubicada en San Juan de
             los Remedios, Villa Clara se le atribuye ser la iglesia más antigua
             de Cuba. La iglesia actual fue construida en 1692 sobre la estructura

--- a/src/frontend/components/contactUs.tsx
+++ b/src/frontend/components/contactUs.tsx
@@ -13,7 +13,7 @@ const ContactUs = () => {
           </h1>
         </div>
         <div className="flex flex-col md:flex-row items-center place-content-center gap-3 p-3 lg:gap-28 font-body">
-          <div className="p-10 w-[390px] h-80" id="contact">
+          <div className="p-10 w-[390px] h-80">
             <h2 className="font-semibold">
               <Trans i18nKey="hours">Horarios</Trans>:
             </h2>

--- a/src/frontend/components/footerApp.tsx
+++ b/src/frontend/components/footerApp.tsx
@@ -4,7 +4,11 @@ import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import Loading from "./loading";
 
-const FooterApp = () => {
+type FooterAppProps = {
+  showContact?: boolean;
+};
+
+const FooterApp = ({ showContact = true }: FooterAppProps) => {
   const { t, i18n } = useTranslation();
 
   if (!i18n.isInitialized) {
@@ -12,19 +16,18 @@ const FooterApp = () => {
   }
 
   return (
-    <div className="anchored-section2" id="contact">
-      <ContactUs />
-      <p className="flex flex-col sm:flex-row p-3 justify-center text-center font-display bg-sanctuaryDeep text-sanctuaryLinen cursor-default">
+    <footer className="bg-sanctuaryDeep text-sanctuaryLinen">
+      {showContact && <ContactUs />}
+      <p className="flex flex-col justify-center gap-1 px-4 py-3 text-center font-display sm:flex-row">
         <span>
           © 2024 Iglesia de San Bautista de{" "}
-          <Link className="cursor-default mr-1 text-sanctuaryGold" href="/secret">
+          <Link className="cursor-default text-sanctuaryGold" href="/secret">
             Remedios.
           </Link>
         </span>
         <span>{t("Todos los derechos reservados.")}</span>
-        {/* Developed by Dmigoya and alex-ohdz */}
       </p>
-    </div>
+    </footer>
   );
 };
 

--- a/src/frontend/components/homeHero.tsx
+++ b/src/frontend/components/homeHero.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+const heroSlides = [
+  {
+    imageUrl:
+      "https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=1600&q=80",
+    titleKey: "hero.slides.0.title",
+    descriptionKey: "hero.slides.0.description",
+  },
+  {
+    imageUrl:
+      "https://images.unsplash.com/photo-1528909514045-2fa4ac7a08ba?auto=format&fit=crop&w=1600&q=80",
+    titleKey: "hero.slides.1.title",
+    descriptionKey: "hero.slides.1.description",
+  },
+  {
+    imageUrl:
+      "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80",
+    titleKey: "hero.slides.2.title",
+    descriptionKey: "hero.slides.2.description",
+  },
+];
+
+const HomeHero = () => {
+  const { t } = useTranslation();
+  const [current, setCurrent] = useState(0);
+
+  const slides = useMemo(() => heroSlides, []);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCurrent((prev) => (prev + 1) % slides.length);
+    }, 8000);
+
+    return () => clearInterval(timer);
+  }, [slides.length]);
+
+  const handleSelect = (index: number) => {
+    setCurrent(index);
+  };
+
+  return (
+    <section className="relative flex h-[60vh] min-h-[320px] items-center justify-center overflow-hidden bg-black text-white md:h-[70vh]">
+      {slides.map((slide, index) => (
+        <div
+          key={slide.imageUrl}
+          className={`absolute inset-0 transition-opacity duration-1000 ease-out ${
+            index === current ? "opacity-100" : "opacity-0"
+          }`}
+        >
+          <img
+            src={slide.imageUrl}
+            alt={`${t("hero.slides." + index + ".title")}`}
+            className="h-full w-full object-cover"
+          />
+          <div className="absolute inset-0 bg-black/50" />
+          <div className="absolute inset-0 flex flex-col items-center justify-center px-6 text-center md:px-12">
+            <h1
+              className={`text-3xl font-display tracking-wide sm:text-4xl md:text-5xl ${
+                index === current ? "translate-y-0 opacity-100" : "translate-y-6 opacity-0"
+              } transition-all duration-700 ease-out`}
+            >
+              {t(slide.titleKey)}
+            </h1>
+            <p
+              className={`mt-4 max-w-2xl text-sm font-body sm:text-base md:text-lg ${
+                index === current ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+              } transition-all duration-700 ease-out delay-150`}
+            >
+              {t(slide.descriptionKey)}
+            </p>
+          </div>
+        </div>
+      ))}
+      <div className="absolute bottom-6 flex gap-2">
+        {slides.map((slide, index) => (
+          <button
+            key={slide.imageUrl}
+            type="button"
+            onClick={() => handleSelect(index)}
+            className={`h-2 w-8 rounded-full transition-all duration-300 ${
+              index === current ? "bg-sanctuaryGold" : "bg-white/50 hover:bg-white/80"
+            }`}
+            aria-label={t("hero.slides." + index + ".title")}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default HomeHero;

--- a/src/frontend/components/navText.tsx
+++ b/src/frontend/components/navText.tsx
@@ -2,10 +2,10 @@ import Link from "next/link";
 import { useTranslation } from "react-i18next";
 
 const items = [
-  { key: "us", link: "#us" },
-  { key: "services", link: "#services" },
-  { key: "contact", link: "#contact" },
-  { key: "donations", link: "donations" },
+  { key: "us", link: "/nosotros" },
+  { key: "services", link: "/servicios" },
+  { key: "contact", link: "/contacto" },
+  { key: "donations", link: "/donations" },
 ];
 
 const NavText = ({ isMobile }) => {

--- a/src/frontend/components/pageShell.tsx
+++ b/src/frontend/components/pageShell.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Suspense, type ReactNode } from "react";
+import Nav from "@components/nav";
+import FooterApp from "@components/footerApp";
+import Loading from "@components/loading";
+
+type PageShellProps = {
+  children: ReactNode;
+  showContactInFooter?: boolean;
+};
+
+const PageShell = ({ children, showContactInFooter = true }: PageShellProps) => {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Nav />
+      <main className="flex flex-1 flex-col bg-sanctuaryLinen">{children}</main>
+      <FooterApp showContact={showContactInFooter} />
+    </Suspense>
+  );
+};
+
+export default PageShell;

--- a/src/frontend/components/sectionHero.tsx
+++ b/src/frontend/components/sectionHero.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import useIntersectionObserver from "@hooks/useIntersectionObserver";
+
+interface SectionHeroProps {
+  imageUrl: string;
+  title: string;
+  description: string;
+}
+
+const SectionHero = ({ imageUrl, title, description }: SectionHeroProps) => {
+  const [ref, isVisible] = useIntersectionObserver({ threshold: 0.3 });
+
+  return (
+    <section className="relative flex h-[45vh] min-h-[280px] items-center justify-center overflow-hidden bg-black text-white md:h-[55vh]">
+      <img src={imageUrl} alt={title} className="absolute inset-0 h-full w-full object-cover" />
+      <div className="absolute inset-0 bg-black/55" />
+      <div
+        ref={ref}
+        className={`relative z-10 mx-auto max-w-3xl px-6 text-center transition-all duration-700 ease-out ${
+          isVisible ? "translate-y-0 opacity-100" : "translate-y-6 opacity-0"
+        }`}
+      >
+        <h1 className="text-3xl font-display tracking-wide sm:text-4xl md:text-5xl">{title}</h1>
+        <p className="mt-4 text-sm font-body sm:text-base md:text-lg">{description}</p>
+      </div>
+    </section>
+  );
+};
+
+export default SectionHero;

--- a/src/frontend/components/services.tsx
+++ b/src/frontend/components/services.tsx
@@ -1,87 +1,55 @@
 "use client";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-// Definición de los servicios
-const servicios = [
-  {
-    id: 1,
-    nombre: "Bautismo",
-    descripcion:
-      "La ceremonia de bautismo es un evento significativo en la vida espiritual de la familia y el infante. Nuestro servicio de bautismo está diseñado para hacer de este momento algo memorable y sagrado, proporcionando una experiencia personalizada que refleje las creencias y deseos de la familia. Desde la planificación hasta la ejecución, cuidamos cada detalle para asegurar que la ceremonia sea hermosa, respetuosa y acorde a tus expectativas.",
-  },
-  {
-    id: 2,
-    nombre: "Boda",
-    descripcion:
-      "Creemos que tu día de boda debe ser tan único como tu amor. Con nuestro servicio de casamientos, te ayudamos a crear una celebración inolvidable que capture perfectamente tu relación. Desde lugares de ensueño hasta decoraciones de ensueño, nuestro equipo está dedicado a convertir tus visiones en realidad, asegurando que cada aspecto de tu boda sea perfecto, sin importar lo grande o pequeño que sea.",
-  },
-  {
-    id: 3,
-    nombre: "Ejemplo 3",
-    descripcion:
-      "Ejemplo 3 ofrece una gama de servicios diseñados para satisfacer tus necesidades específicas. Ya sea que estés buscando expandir tu negocio, mejorar tu bienestar personal o celebrar un hito, nuestro equipo dedicado está aquí para apoyarte. Con un enfoque personalizado y una atención meticulosa al detalle, nos esforzamos por superar tus expectativas y proporcionarte resultados excepcionales.",
-  },
+const serviceKeys = [
+  { id: 1, key: "baptism" },
+  { id: 2, key: "wedding" },
+  { id: 3, key: "community" },
 ];
 
 function Services() {
   const { t } = useTranslation();
-  const [value, setValue] = useState(1);
+  const [value, setValue] = useState(serviceKeys[0].id);
 
-  const handleChange = (id) => {
-    setValue(id);
-  };
+  const services = useMemo(
+    () =>
+      serviceKeys.map(({ id, key }) => ({
+        id,
+        key,
+        title: t(`services.items.${key}.title`),
+        description: t(`services.items.${key}.description`),
+      })),
+    [t]
+  );
 
-  const selectServices = servicios.find((servicio) => servicio.id === value);
+  const selected = services.find((service) => service.id === value) ?? services[0];
 
   return (
-    <div className="font-body bg-sanctuaryLinen anchored-section2" id="services">
-      <h1 className="text-center py-6 text-2xl font-display text-sanctuaryBrick">{t(`Servicios`)}</h1>
-      <div className="flex justify-between h-14 w-full">
-        <div className="flex justify-center items-center h-full w-1/3">
-          <button
-            className={`h-full w-full text-white transition ${
-              value === 1
-                ? "bg-sanctuaryBrick/90"
-                : "bg-sanctuaryTerracotta hover:bg-sanctuaryBrick/80"
-            }`}
-            onClick={() => handleChange(1)}
-            disabled={value === 1}
-          >
-            Bautismos
-          </button>
+    <section className="bg-sanctuaryLinen py-12">
+      <div className="mx-auto max-w-4xl px-6 font-body text-sanctuaryDeep">
+        <h1 className="text-center font-display text-3xl text-sanctuaryBrick">{t("services.heading")}</h1>
+        <div className="mt-8 grid gap-4 sm:grid-cols-3">
+          {services.map((service) => (
+            <button
+              key={service.id}
+              type="button"
+              onClick={() => setValue(service.id)}
+              className={`rounded-full px-4 py-3 text-sm font-display uppercase tracking-widest transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+                service.id === selected.id
+                  ? "bg-sanctuaryBrick text-sanctuaryLinen shadow-lg"
+                  : "bg-sanctuaryTerracotta/80 text-sanctuaryLinen hover:bg-sanctuaryTerracotta"
+              }`}
+            >
+              {service.title}
+            </button>
+          ))}
         </div>
-        <div className="flex justify-center items-center h-full w-1/3">
-          <button
-            className={`h-full w-full text-white transition ${
-              value === 2
-                ? "bg-sanctuaryBrick/90"
-                : "bg-sanctuaryTerracotta hover:bg-sanctuaryBrick/80"
-            }`}
-            onClick={() => handleChange(2)}
-            disabled={value === 2}
-          >
-            Boda
-          </button>
-        </div>
-        <div className="flex justify-center items-center h-full w-1/3">
-          <button
-            className={`h-full w-full text-white transition ${
-              value === 3
-                ? "bg-sanctuaryBrick/90"
-                : "bg-sanctuaryTerracotta hover:bg-sanctuaryBrick/80"
-            }`}
-            onClick={() => handleChange(3)}
-            disabled={value === 3}
-          >
-            Lorem
-          </button>
+        <div className="mt-10 rounded-xl bg-white/80 p-6 text-center text-base shadow-md md:text-lg">
+          {selected.description}
         </div>
       </div>
-      <div className="flex mx-10 py-10 items-center justify-center text-md text-sanctuaryDeep">
-        {selectServices.descripcion}
-      </div>
-    </div>
+    </section>
   );
 }
 

--- a/src/frontend/components/weAre.tsx
+++ b/src/frontend/components/weAre.tsx
@@ -25,7 +25,7 @@ const ImageCircle = () => {
   }, []);
 
   return (
-    <div className="bg-sanctuaryLinen p-5 anchored-section" id="us">
+    <div className="bg-sanctuaryLinen p-5">
       <h2 className="text-3xl mb-8 text-center font-display text-sanctuaryBrick">{t('Nuestro Equipo')}</h2>
       <div className="flex flex-wrap justify-center gap-8">
         {teamMembers.map((member, index) => (


### PR DESCRIPTION
## Summary
- replace the single-page layout with a shared shell and dedicated routes for the home, "nosotros", "servicios", and "contacto" sections while keeping the navigation and footer consistent
- add animated hero components and placeholder imagery so every section highlights its content with dynamic text and visuals
- refresh translations and the services component so copy is driven from i18n keys across the new pages

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d000f15098832ca747998f8120aa8f