### PR TITLE
Refresh navigation and language switcher styling

### DIFF
--- a/pages/api/getActivities.ts
+++ b/pages/api/getActivities.ts
@@ -11,7 +11,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const activities = await listActivities();
     res.status(200).json({ success: true, data: activities });
   } catch (error) {
-    console.error("Error fetching data", error);
     res.status(500).json({ success: false, error: "Error fetching data" });
   }
 }

--- a/pages/api/getWorkers.ts
+++ b/pages/api/getWorkers.ts
@@ -11,7 +11,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const workers = await listWorkers();
     res.status(200).json({ success: true, data: workers });
   } catch (error) {
-    console.error("Error fetching data", error);
     res.status(500).json({ success: false, error: "Error fetching data" });
   }
 }

--- a/src/frontend/components/homeHero.tsx
+++ b/src/frontend/components/homeHero.tsx
@@ -43,7 +43,7 @@ const HomeHero = () => {
   };
 
   return (
-    <section className="relative flex h-[60vh] min-h-[320px] items-center justify-center overflow-hidden bg-black text-white md:h-[70vh]">
+    <section className="relative mt-[-80px] flex h-[60vh] min-h-[320px] items-center justify-center overflow-hidden bg-black text-white md:mt-[-96px] md:h-[70vh]">
       {slides.map((slide, index) => (
         <div
           key={slide.imageUrl}

--- a/src/frontend/components/langChanger.tsx
+++ b/src/frontend/components/langChanger.tsx
@@ -1,31 +1,66 @@
 "use client";
+
 import { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronUpIcon } from "@components/icons";
 
-const flags = [
-  { code: "en", imgF: "/icons/flags/en.png" },
-  { code: "es", imgF: "/icons/flags/es.png" },
-  { code: "po", imgF: "/icons/flags/po.png" },
+type LangChangerProps = {
+  variant?: "solid" | "overlay";
+};
+
+type FlagOption = {
+  code: string;
+  imgF: string;
+  label: string;
+};
+
+const flags: FlagOption[] = [
+  { code: "en", imgF: "/icons/flags/en.png", label: "English" },
+  { code: "es", imgF: "/icons/flags/es.png", label: "Español" },
+  { code: "po", imgF: "/icons/flags/po.png", label: "Português" },
 ];
 
-const LangChanger = () => {
+const variantStyles = {
+  solid: {
+    button:
+      "border border-sanctuaryBrick/20 bg-white text-sanctuaryBrick shadow-lg hover:bg-sanctuaryCream/70",
+    icon: "text-sanctuaryBrick",
+    dropdown:
+      "border border-sanctuaryBrick/15 bg-white/95 text-sanctuaryBrick backdrop-blur",
+    option: "hover:bg-sanctuaryCream/50",
+    label: "",
+  },
+  overlay: {
+    button:
+      "border border-white/40 bg-white/10 text-white shadow-[0_10px_30px_rgba(0,0,0,0.3)] backdrop-blur-lg hover:bg-white/20",
+    icon: "text-white",
+    dropdown: "border border-white/25 bg-black/60 text-white backdrop-blur-xl",
+    option: "hover:bg-white/10",
+    label: "drop-shadow-[0_1px_4px_rgba(0,0,0,0.45)]",
+  },
+};
+
+const getFlagByCode = (code: string) => flags.find((flag) => flag.code === code);
+
+const LangChanger = ({ variant = "solid" }: LangChangerProps) => {
   const { i18n } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedFlag, setSelectedFlag] = useState(
-    () => flags.find((flag) => flag.code === i18n.language) || flags[1]
-  );
   const dropdownRef = useRef<HTMLDivElement | null>(null);
-  const fileId = selectedFlag.code;
+  const normalizedLanguage = (i18n.language || "").split("-")[0];
+  const [selectedFlag, setSelectedFlag] = useState<FlagOption>(
+    () => getFlagByCode(normalizedLanguage) ?? flags[1]
+  );
+
+  const styles = variantStyles[variant] ?? variantStyles.solid;
 
   const toggleDropdown = () => {
-    setIsOpen(!isOpen);
+    setIsOpen((prev) => !prev);
   };
 
-  const handleSelectFlag = (flag) => {
+  const handleSelectFlag = (flag: FlagOption) => {
     setSelectedFlag(flag);
     setIsOpen(false);
-    i18n.changeLanguage(flag.code);
+    void i18n.changeLanguage(flag.code);
   };
 
   useEffect(() => {
@@ -34,52 +69,87 @@ const LangChanger = () => {
         setIsOpen(false);
       }
     };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
     document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
     };
   }, []);
 
   useEffect(() => {
-    const currentFlag = flags.find((flag) => flag.code === i18n.language);
+    const currentLanguage = (i18n.language || "").split("-")[0];
+    const currentFlag = getFlagByCode(currentLanguage);
+
     if (currentFlag && currentFlag.code !== selectedFlag.code) {
       setSelectedFlag(currentFlag);
     }
   }, [i18n.language, selectedFlag.code]);
 
   return (
-    <div
-      ref={dropdownRef}
-      className={`relative ml-2 rounded-md p-1 transition ${isOpen ? "bg-sanctuaryCream" : ""}`}
-    >
-      <button onClick={toggleDropdown} className="flex items-center gap-1">
-        <img
-          src={selectedFlag.imgF}
-          alt={`${selectedFlag.code} flag`}
-          className="h-6 w-6"
-        />
+    <div ref={dropdownRef} className="relative">
+      <button
+        type="button"
+        onClick={toggleDropdown}
+        className={`group flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.25em] transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sanctuaryGold focus-visible:ring-offset-2 focus-visible:ring-offset-transparent sm:text-sm ${styles.button}`}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-label="Cambiar idioma"
+      >
+        <span className="relative flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-white/90 shadow-inner ring-1 ring-black/5 transition-transform duration-300 group-hover:scale-105">
+          <img
+            src={selectedFlag.imgF}
+            alt={`${selectedFlag.label} flag`}
+            className="h-full w-full object-cover"
+          />
+        </span>
+        <span className={`block sm:hidden ${styles.label}`}>
+          {selectedFlag.code.toUpperCase()}
+        </span>
+        <span className={`hidden sm:inline ${styles.label}`}>{selectedFlag.label}</span>
         <ChevronUpIcon
-          className={`h-4 w-4 text-sanctuaryBrick transition-transform duration-200 ${
-            isOpen ? "rotate-180" : ""
-          }`}
+          className={`h-4 w-4 transition-transform duration-300 ${isOpen ? "rotate-180" : ""} ${styles.icon}`}
         />
       </button>
-      {isOpen && (
-        <div className="absolute right-0 top-8 z-20 flex flex-col items-center gap-1 rounded-md bg-sanctuaryCream p-2 shadow-md">
+      <div
+        className={`absolute right-0 top-12 z-50 w-44 origin-top rounded-2xl px-3 py-3 shadow-xl transition-all duration-300 ${
+          styles.dropdown
+        } ${isOpen ? "pointer-events-auto translate-y-0 scale-100 opacity-100" : "pointer-events-none -translate-y-2 scale-95 opacity-0"}`}
+        role="listbox"
+        aria-hidden={!isOpen}
+      >
+        <ul className="flex flex-col gap-1">
           {flags
             .filter((flag) => flag.code !== selectedFlag.code)
             .map((flag) => (
-              <button
-                key={`${fileId}-${flag.code}`}
-                type="button"
-                onClick={() => handleSelectFlag(flag)}
-                className="rounded-md p-1 transition hover:bg-sanctuaryGold/20"
-              >
-                <img src={flag.imgF} alt={`${flag.code} flag`} className="h-6 w-6" />
-              </button>
+              <li key={flag.code}>
+                <button
+                  type="button"
+                  onClick={() => handleSelectFlag(flag)}
+                  className={`flex w-full items-center gap-3 rounded-xl px-2 py-2 text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sanctuaryGold/70 ${styles.option}`}
+                  role="option"
+                  aria-selected={false}
+                >
+                  <span className="relative flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-white/90 shadow-inner ring-1 ring-black/5">
+                    <img
+                      src={flag.imgF}
+                      alt={`${flag.label} flag`}
+                      className="h-full w-full object-cover"
+                    />
+                  </span>
+                  <span>{flag.label}</span>
+                </button>
+              </li>
             ))}
-        </div>
-      )}
+        </ul>
+      </div>
     </div>
   );
 };

--- a/src/frontend/components/nav.tsx
+++ b/src/frontend/components/nav.tsx
@@ -1,27 +1,29 @@
 "use client";
+
 import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 import NavPC from "@components/navPC";
 import NavMobile from "@components/navMobile";
+
 export default function Nav() {
-  const [isMobile, setIsMobile] = useState(false);
+  const pathname = usePathname();
+  const [isDesktop, setIsDesktop] = useState(() =>
+    typeof window !== "undefined" ? window.innerWidth >= 1024 : false
+  );
 
   useEffect(() => {
-    function handleResize() {
-      setIsMobile(window.innerWidth > 800);
-    }
-    window.addEventListener("resize", handleResize);
+    const handleResize = () => {
+      setIsDesktop(window.innerWidth >= 1024);
+    };
+
     handleResize();
+    window.addEventListener("resize", handleResize);
     return () => {
       window.removeEventListener("resize", handleResize);
     };
   }, []);
-  return (
-    <div>
-      {isMobile ? (
-        <NavPC isMobile={isMobile} />
-      ) : (
-        <NavMobile isMobile={isMobile} />
-      )}
-    </div>
-  );
+
+  const isHome = pathname === "/";
+
+  return isDesktop ? <NavPC isHome={isHome} /> : <NavMobile isHome={isHome} />;
 }

--- a/src/frontend/components/navMobile.tsx
+++ b/src/frontend/components/navMobile.tsx
@@ -1,17 +1,22 @@
 "use client";
+
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Bars3Icon, XMarkIcon } from "@components/icons";
 import LangChanger from "./langChanger";
 import NavText from "./navText";
 
-function NavMobile({ isMobile }) {
+type NavMobileProps = {
+  isHome: boolean;
+};
+
+function NavMobile({ isHome }: NavMobileProps) {
   const [scrolled, setScrolled] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => {
-      setScrolled(window.scrollY > 0);
+      setScrolled(window.scrollY > 40);
     };
 
     handleScroll();
@@ -19,55 +24,83 @@ function NavMobile({ isMobile }) {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
+  const navVariant: "solid" | "overlay" = isHome && !scrolled ? "overlay" : "solid";
+
+  const headerClasses =
+    navVariant === "overlay"
+      ? "bg-gradient-to-b from-black/70 via-black/30 to-transparent text-white backdrop-blur-sm"
+      : "bg-sanctuaryLinen/95 text-sanctuaryBrick shadow-lg backdrop-blur";
+
+  const borderClasses =
+    navVariant === "overlay" ? "border-white/10" : "border-sanctuaryBrick/10";
+
+  const titleClasses =
+    navVariant === "overlay"
+      ? "text-white drop-shadow-[0_1px_6px_rgba(0,0,0,0.35)]"
+      : "text-sanctuaryBrick";
+
+  const iconButtonClasses =
+    navVariant === "overlay"
+      ? "text-white hover:bg-white/10"
+      : "text-sanctuaryBrick hover:bg-sanctuaryCream";
+
   const toggleDrawer = () => setIsDrawerOpen((prev) => !prev);
   const closeDrawer = () => setIsDrawerOpen(false);
 
   return (
     <>
       <header
-        className={`fixed top-0 z-50 w-full bg-white/95 backdrop-blur transition-shadow duration-300 ${
-          scrolled ? "shadow-md" : "shadow-none"
-        }`}
+        className={`fixed top-0 z-50 w-full border-b ${borderClasses} transition-all duration-500 ${headerClasses}`}
       >
         <div className="flex items-center justify-between px-4 py-3">
-          <Link href="/">
-            <h1 className="text-sanctuaryBrick font-display text-lg">
+          <Link
+            href="/"
+            className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sanctuaryGold focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+          >
+            <h1
+              className={`font-display text-sm uppercase tracking-[0.25em] transition-colors duration-300 ${titleClasses}`}
+            >
               San Juan Bautista de Remedios
             </h1>
           </Link>
           <div className="flex items-center gap-3">
-            <LangChanger />
+            <LangChanger variant={navVariant} />
             <button
               type="button"
               onClick={toggleDrawer}
               aria-label="Abrir menú"
-              className="rounded-md p-2 text-sanctuaryBrick transition hover:bg-sanctuaryCream"
+              aria-expanded={isDrawerOpen}
+              className={`rounded-full p-2 transition ${iconButtonClasses}`}
             >
               <Bars3Icon className="h-7 w-7" />
             </button>
           </div>
         </div>
       </header>
-      <div className="h-16" />
       {isDrawerOpen && (
         <div className="fixed inset-0 z-40 flex">
           <div
-            className="absolute inset-0 bg-black/40"
+            className="absolute inset-0 bg-black/40 backdrop-blur-sm"
             onClick={closeDrawer}
             aria-hidden="true"
           />
-          <aside className="relative ml-auto flex h-full w-64 flex-col bg-sanctuaryLinen/95 p-4 shadow-lg transition-transform">
+          <aside
+            className="relative ml-auto flex h-full w-64 translate-x-0 flex-col bg-sanctuaryLinen/95 p-4 shadow-2xl transition-transform duration-300"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Menú de navegación"
+          >
             <button
               type="button"
               onClick={closeDrawer}
               aria-label="Cerrar menú"
-              className="self-end rounded-md p-2 text-sanctuaryBrick transition hover:bg-sanctuaryCream"
+              className="self-end rounded-full p-2 text-sanctuaryBrick transition hover:bg-sanctuaryCream"
             >
               <XMarkIcon className="h-6 w-6" />
             </button>
-            <nav className="mt-4">
-              <NavText isMobile={isMobile} />
-            </nav>
+            <div className="mt-6">
+              <NavText layout="vertical" onNavigate={closeDrawer} />
+            </div>
           </aside>
         </div>
       )}

--- a/src/frontend/components/navPC.tsx
+++ b/src/frontend/components/navPC.tsx
@@ -5,12 +5,16 @@ import Link from "next/link";
 import LangChanger from "./langChanger";
 import NavText from "./navText";
 
-function NavPC({ isMobile }) {
+type NavPCProps = {
+  isHome: boolean;
+};
+
+function NavPC({ isHome }: NavPCProps) {
   const [scrolled, setScrolled] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => {
-      setScrolled(window.scrollY > 0);
+      setScrolled(window.scrollY > 40);
     };
 
     handleScroll();
@@ -18,27 +22,42 @@ function NavPC({ isMobile }) {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
+  const navVariant: "solid" | "overlay" = isHome && !scrolled ? "overlay" : "solid";
+
+  const headerClasses =
+    navVariant === "overlay"
+      ? "bg-gradient-to-b from-black/60 via-black/20 to-transparent text-white backdrop-blur-sm"
+      : "bg-sanctuaryLinen/95 text-sanctuaryBrick shadow-lg backdrop-blur";
+
+  const borderClasses =
+    navVariant === "overlay" ? "border-white/10" : "border-sanctuaryBrick/10";
+
+  const titleClasses =
+    navVariant === "overlay"
+      ? "text-white drop-shadow-[0_1px_6px_rgba(0,0,0,0.35)]"
+      : "text-sanctuaryBrick";
+
   return (
-    <>
-      <header
-        className={`fixed top-0 z-50 w-full bg-white/95 backdrop-blur transition-shadow duration-300 ${
-          scrolled ? "shadow-md" : "shadow-none"
-        }`}
-      >
-        <div className="mx-auto flex max-w-6xl items-center px-4 py-3 md:px-8">
-          <Link href="/">
-            <h1 className="text-sanctuaryBrick font-display text-lg sm:text-xl md:text-2xl">
-              San Juan Bautista de Remedios
-            </h1>
-          </Link>
-          <div className="flex flex-1 items-center justify-end gap-6">
-            <NavText isMobile={isMobile} />
-            <LangChanger />
-          </div>
+    <header
+      className={`fixed top-0 z-50 w-full border-b ${borderClasses} transition-all duration-500 ${headerClasses}`}
+    >
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 md:px-8">
+        <Link
+          href="/"
+          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sanctuaryGold focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+        >
+          <h1
+            className={`font-display text-base uppercase tracking-[0.2em] transition-colors duration-300 sm:text-lg md:text-xl ${titleClasses}`}
+          >
+            San Juan Bautista de Remedios
+          </h1>
+        </Link>
+        <div className="flex items-center gap-5 md:gap-6">
+          <NavText layout="horizontal" variant={navVariant} />
+          <LangChanger variant={navVariant} />
         </div>
-      </header>
-      <div className="h-16" />
-    </>
+      </div>
+    </header>
   );
 }
 

--- a/src/frontend/components/navText.tsx
+++ b/src/frontend/components/navText.tsx
@@ -8,24 +8,48 @@ const items = [
   { key: "donations", link: "/donations" },
 ];
 
-const NavText = ({ isMobile }) => {
+type NavTextProps = {
+  layout?: "horizontal" | "vertical";
+  variant?: "solid" | "overlay";
+  onNavigate?: () => void;
+};
+
+const NavText = ({ layout = "horizontal", variant = "solid", onNavigate }: NavTextProps) => {
   const { t } = useTranslation();
 
+  const containerClasses =
+    layout === "horizontal"
+      ? "flex flex-row items-center gap-6"
+      : "flex flex-col items-start gap-5";
+
+  const linkBaseClasses =
+    "font-display text-base sm:text-lg uppercase tracking-[0.15em] transition-colors duration-300";
+
+  const colorClasses =
+    variant === "overlay"
+      ? "text-white drop-shadow-[0_1px_4px_rgba(0,0,0,0.45)] hover:text-sanctuaryGold"
+      : "text-sanctuaryBrick hover:text-sanctuaryGold";
+
+  const handleClick = () => {
+    onNavigate?.();
+  };
+
   return (
-    <div className={`flex ${isMobile ? 'flex-row' : 'flex-col'} items-center`}>
-      {items.map((item, index) => {
-        return (
-          <div className={`${isMobile ? 'px-2' : 'mb-5'}`} key={index}>
+    <nav aria-label="Navegación principal">
+      <ul className={containerClasses}>
+        {items.map((item) => (
+          <li key={item.key}>
             <Link
               href={item.link}
-              className="text-sanctuaryBrick hover:text-sanctuaryGold transition-colors duration-300 text-lg font-display tracking-wider"
+              className={`${linkBaseClasses} ${colorClasses}`}
+              onClick={handleClick}
             >
               {t(`navigation.${item.key}`)}
             </Link>
-          </div>
-        );
-      })}
-    </div>
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
 };
 

--- a/src/frontend/components/pageShell.tsx
+++ b/src/frontend/components/pageShell.tsx
@@ -14,7 +14,9 @@ const PageShell = ({ children, showContactInFooter = true }: PageShellProps) => 
   return (
     <Suspense fallback={<Loading />}>
       <Nav />
-      <main className="flex flex-1 flex-col bg-sanctuaryLinen">{children}</main>
+      <main className="flex flex-1 flex-col bg-sanctuaryLinen pt-20 md:pt-24">
+        {children}
+      </main>
       <FooterApp showContact={showContactInFooter} />
     </Suspense>
   );

--- a/src/frontend/i18next.config.ts
+++ b/src/frontend/i18next.config.ts
@@ -37,7 +37,7 @@ if (!i18n.isInitialized) {
             },
           }
         : {}),
-      debug: process.env.NODE_ENV === "development",
+      debug: process.env.NEXT_PUBLIC_I18N_DEBUG === "true",
     })
     .catch((error) => {
       console.error("Error initializing i18next:", error);


### PR DESCRIPTION
## Summary
- silence i18next debug logging and remove API console errors to keep the console clean
- redesign the desktop and mobile navigation so it overlays the home carousel, sticks on scroll, and adapts colors per context
- restyle the language switcher dropdown with an animated, polished look and updated spacing for the hero section

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d015f1eabc832c9a44ccdcd8b14754