### PR TITLE
Fix navigation hydration mismatch and add home links

### DIFF
--- a/src/frontend/app/cancel/page.tsx
+++ b/src/frontend/app/cancel/page.tsx
@@ -1,9 +1,23 @@
+import Link from "next/link";
+import PageShell from "@components/pageShell";
+
 export default function CancelPage() {
-	return (
-	  <div className="p-4 bg-gray-100 rounded-md shadow-md">
-		<h1 className="text-3xl font-bold mb-4">Pago cancelado</h1>
-		<p>Tu donación ha sido cancelada. Puedes intentarlo de nuevo.</p>
-	  </div>
-	);
-  }
-  
+  return (
+    <PageShell>
+      <section className="flex min-h-[60vh] items-center justify-center px-4 py-20">
+        <div className="max-w-xl rounded-2xl bg-white p-8 text-center shadow-xl">
+          <h1 className="mb-4 text-3xl font-display text-sanctuaryBrick">Pago cancelado</h1>
+          <p className="mb-8 font-body text-sanctuaryDeep">
+            Tu donación ha sido cancelada. Puedes intentarlo de nuevo.
+          </p>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-full bg-sanctuaryBrick px-6 py-3 font-display text-sm uppercase tracking-widest text-sanctuaryLinen shadow-md transition hover:bg-sanctuaryTerracotta"
+          >
+            Volver al inicio
+          </Link>
+        </div>
+      </section>
+    </PageShell>
+  );
+}

--- a/src/frontend/app/success/page.tsx
+++ b/src/frontend/app/success/page.tsx
@@ -1,8 +1,25 @@
+import Link from "next/link";
+import PageShell from "@components/pageShell";
+
 export default function SuccessPage() {
   return (
-    <div className="p-4 bg-gray-100 rounded-md shadow-md">
-      <h1 className="text-3xl font-bold mb-4">¡Gracias por tu donación!</h1>
-      <p>Tu donación ha sido procesada exitosamente.</p>
-    </div>
+    <PageShell>
+      <section className="flex min-h-[60vh] items-center justify-center px-4 py-20">
+        <div className="max-w-xl rounded-2xl bg-white p-8 text-center shadow-xl">
+          <h1 className="mb-4 text-3xl font-display text-sanctuaryBrick">
+            ¡Gracias por tu donación!
+          </h1>
+          <p className="mb-8 font-body text-sanctuaryDeep">
+            Tu donación ha sido procesada exitosamente.
+          </p>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-full bg-sanctuaryBrick px-6 py-3 font-display text-sm uppercase tracking-widest text-sanctuaryLinen shadow-md transition hover:bg-sanctuaryTerracotta"
+          >
+            Volver al inicio
+          </Link>
+        </div>
+      </section>
+    </PageShell>
   );
 }

--- a/src/frontend/components/nav.tsx
+++ b/src/frontend/components/nav.tsx
@@ -7,11 +7,13 @@ import NavMobile from "@components/navMobile";
 
 export default function Nav() {
   const pathname = usePathname();
-  const [isDesktop, setIsDesktop] = useState(() =>
-    typeof window !== "undefined" ? window.innerWidth >= 1024 : false
-  );
+  const [isDesktop, setIsDesktop] = useState(false);
 
   useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
     const handleResize = () => {
       setIsDesktop(window.innerWidth >= 1024);
     };


### PR DESCRIPTION
## Summary
- ensure the navigation always hydrates consistently by deferring layout detection to the client effect
- wrap donation success and cancellation pages with the shared layout and add a clear link back to the homepage

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0524e94cc832c8cf2bea7abc5ab65