### PR TITLE
Revamp admin zones for desktop workflow

### DIFF
--- a/src/frontend/components/adminPage/adminHome.tsx
+++ b/src/frontend/components/adminPage/adminHome.tsx
@@ -47,35 +47,35 @@ const AdminHome = () => {
   const SelectedZoneComponent = selectedZone.component;
 
   return (
-    <div className="flex min-h-screen flex-col bg-slate-100">
+    <div className="flex min-h-screen flex-col bg-slate-100 font-sans text-slate-900">
       <AdminNavbar showSections={false} />
-      <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-4 py-10">
-        <section className="rounded-2xl bg-white p-6 shadow-lg">
-          <h2 className="text-2xl font-semibold text-sanctuaryBrick">
+      <main className="mx-auto flex w-full max-w-[1600px] flex-1 flex-col gap-10 px-8 py-12">
+        <section className="rounded-3xl border border-slate-200 bg-white px-10 py-8 shadow-xl">
+          <h2 className="text-3xl font-bold leading-tight text-sanctuaryBrick">
             Centro de administración del santuario
           </h2>
-          <p className="mt-3 text-sm text-slate-600">
+          <p className="mt-4 max-w-4xl text-base leading-relaxed text-slate-600">
             Dividimos las herramientas en zonas claras para que puedas ubicar
             rápidamente lo que necesitas. Usa el panel lateral para elegir qué
             parte del sitio deseas actualizar.
           </p>
-          <p className="mt-2 text-sm text-slate-600">
+          <p className="mt-3 max-w-4xl text-base leading-relaxed text-slate-600">
             Cada sección incluye una explicación breve de su propósito y el
             formulario correspondiente para mantener el contenido del sitio
             siempre al día.
           </p>
         </section>
-        <section className="grid gap-6 lg:grid-cols-[320px,1fr]">
-          <aside className="space-y-4">
-            <div>
-              <h3 className="text-sm font-semibold uppercase tracking-wide text-sanctuaryTerracotta">
+        <section className="grid gap-8 lg:grid-cols-[360px,1fr]">
+          <aside className="space-y-6">
+            <div className="rounded-3xl border border-slate-200 bg-white px-6 py-5 shadow">
+              <h3 className="text-xs font-semibold uppercase tracking-[0.3em] text-sanctuaryTerracotta">
                 Zonas de gestión
               </h3>
-              <p className="mt-1 text-xs text-slate-500">
+              <p className="mt-2 text-sm leading-6 text-slate-500">
                 Selecciona una categoría para ver sus detalles y herramientas.
               </p>
             </div>
-            <ul className="flex flex-col gap-3">
+            <ul className="flex flex-col gap-4">
               {adminZones.map((zone) => {
                 const isActive = zone.id === selectedZone.id;
                 return (
@@ -83,16 +83,16 @@ const AdminHome = () => {
                     <button
                       type="button"
                       onClick={() => setSelectedZoneId(zone.id)}
-                      className={`w-full rounded-2xl border bg-white p-4 text-left transition focus:outline-none focus:ring-2 focus:ring-sanctuaryTerracotta focus:ring-offset-2 ${
+                      className={`w-full rounded-3xl border bg-white px-6 py-5 text-left text-base font-semibold transition focus:outline-none focus:ring-2 focus:ring-sanctuaryTerracotta focus:ring-offset-2 ${
                         isActive
-                          ? "border-sanctuaryBrick shadow-lg"
-                          : "border-sanctuaryGold/60 hover:border-sanctuaryTerracotta/80 hover:shadow"
+                          ? "border-sanctuaryBrick text-sanctuaryBrick shadow-lg"
+                          : "border-sanctuaryGold/60 text-slate-600 hover:border-sanctuaryTerracotta/80 hover:text-sanctuaryBrick hover:shadow"
                       }`}
                     >
-                      <span className="block text-sm font-semibold text-sanctuaryBrick">
+                      <span className="block text-lg font-bold leading-6">
                         {zone.title}
                       </span>
-                      <span className="mt-1 block text-xs text-slate-500">
+                      <span className="mt-2 block text-sm font-normal leading-6">
                         {zone.summary}
                       </span>
                     </button>
@@ -101,16 +101,16 @@ const AdminHome = () => {
               })}
             </ul>
           </aside>
-          <div className="rounded-2xl bg-white p-6 shadow-lg">
-            <header className="border-b border-slate-200 pb-4">
-              <h3 className="text-xl font-semibold text-sanctuaryBrick">
+          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl">
+            <header className="border-b border-slate-200 pb-6">
+              <h3 className="text-2xl font-bold leading-7 text-sanctuaryBrick">
                 {selectedZone.title}
               </h3>
-              <p className="mt-2 text-sm text-slate-600">
+              <p className="mt-3 max-w-3xl text-base leading-relaxed text-slate-600">
                 {selectedZone.description}
               </p>
             </header>
-            <div className="mt-6">
+            <div className="mt-8">
               <SelectedZoneComponent />
             </div>
           </div>

--- a/src/frontend/components/adminPage/adminNavbar.tsx
+++ b/src/frontend/components/adminPage/adminNavbar.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 type AdminNavbarProps = {
   sections?: Array<{ id: string; label: string }>;
   currentSection?: string;
@@ -23,37 +25,47 @@ const AdminNavbar = ({
 
   return (
     <header className="sticky top-0 z-40 border-b border-sanctuaryGold/40 bg-white/90 backdrop-blur">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-4 px-8 py-5 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sanctuaryTerracotta">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-sanctuaryTerracotta">
             Panel Administrativo
           </p>
-          <h1 className="text-2xl font-display text-sanctuaryBrick">Centro de Gestión</h1>
+          <h1 className="text-3xl font-bold leading-tight text-sanctuaryBrick">
+            Centro de Gestión
+          </h1>
         </div>
-        {showSections && sections.length > 0 && (
-          <nav
-            aria-label="Secciones del panel administrativo"
-            className="flex flex-wrap items-center justify-end gap-2"
+        <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-full border border-sanctuaryTerracotta px-5 py-2 text-sm font-semibold text-sanctuaryTerracotta transition hover:border-sanctuaryBrick hover:bg-sanctuaryBrick hover:text-white focus:outline-none focus:ring-2 focus:ring-sanctuaryTerracotta focus:ring-offset-2"
           >
-            {sections.map((section) => {
-              const isActive = section.id === currentSection;
-              return (
-                <button
-                  key={section.id}
-                  type="button"
-                  onClick={() => handleSectionClick(section.id)}
-                  className={`rounded-full border px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-sanctuaryTerracotta focus:ring-offset-2 ${
-                    isActive
-                      ? "border-sanctuaryBrick bg-sanctuaryBrick text-white shadow"
-                      : "border-sanctuaryTerracotta text-sanctuaryTerracotta hover:bg-sanctuaryTerracotta/10"
-                  }`}
-                >
-                  {section.label}
-                </button>
-              );
-            })}
-          </nav>
-        )}
+            Volver al inicio
+          </Link>
+          {showSections && sections.length > 0 && (
+            <nav
+              aria-label="Secciones del panel administrativo"
+              className="flex flex-wrap items-center justify-end gap-2"
+            >
+              {sections.map((section) => {
+                const isActive = section.id === currentSection;
+                return (
+                  <button
+                    key={section.id}
+                    type="button"
+                    onClick={() => handleSectionClick(section.id)}
+                    className={`rounded-full border px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-sanctuaryTerracotta focus:ring-offset-2 ${
+                      isActive
+                        ? "border-sanctuaryBrick bg-sanctuaryBrick text-white shadow"
+                        : "border-sanctuaryTerracotta text-sanctuaryTerracotta hover:bg-sanctuaryTerracotta/10"
+                    }`}
+                  >
+                    {section.label}
+                  </button>
+                );
+              })}
+            </nav>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/src/frontend/components/adminPage/home-carousel/homeCarousel.tsx
+++ b/src/frontend/components/adminPage/home-carousel/homeCarousel.tsx
@@ -36,62 +36,143 @@ const HomeCarousel = () => {
     return url ?? "";
   };
 
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (event.dataTransfer.files?.length) {
+      handleFilesSelected(
+        event.dataTransfer.files,
+        selectedFiles,
+        setSelectedFiles,
+        setError
+      );
+    }
+  };
+
+  const handleMoveSelectedImage = (index: number, direction: number) => {
+    setSelectedFiles((prevFiles) => {
+      const nextIndex = index + direction;
+      if (nextIndex < 0 || nextIndex >= prevFiles.length) {
+        return prevFiles;
+      }
+
+      const updated = [...prevFiles];
+      const temp = updated[index];
+      updated[index] = updated[nextIndex];
+      updated[nextIndex] = temp;
+      return updated;
+    });
+  };
+
   return (
-    <div className="flex flex-col justify-center items-center w-full relative">
-      <h1 className="font-display text-3xl py-5 text-sanctuaryBrick">
-        Imágenes en el Carrusel
-      </h1>
-      <ProgressBar progress={uploadProgress} uploading={uploading} />
-      <ImageInput
-        onFilesSelected={(files) =>
-          handleFilesSelected(files, selectedFiles, setSelectedFiles, setError)
-        }
-      />
-      <ImagePreview
-        selectedFiles={selectedFiles}
-        onDelete={(index) => handleDeleteSelected(index, setSelectedFiles)}
-      />
-      <button
-        type="button"
-        onClick={() =>
-          handleUpload(
-            selectedFiles,
-            setUploading,
-            setUploadProgress,
-            setSelectedFiles,
-            fetchImages,
-            setUploadedImages
-          )
-        }
-        disabled={selectedFiles.length === 0 || uploading}
-        className="mt-6 flex items-center gap-2 rounded-md bg-green-600 px-4 py-2 text-white transition hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-gray-400"
-      >
-        <ArrowUpTrayIcon className="h-5 w-5" />
-        Subir imágenes
-      </button>
-      <ErrorMessage error={error} />
-      <h1 className="font-display text-2xl py-5 mt-8 text-sanctuaryBrick">Imágenes en la base de datos Carrusel</h1>
-      <div className="bg-sanctuaryCream mt-4 mx-10 mb-10 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-        {uploadedImages.map((image, index) => (
-          <div key={index} className="relative h-52">
-            <div className="h-40 bg-blue-400">
+    <div className="grid gap-8 xl:grid-cols-[minmax(0,420px),1fr] xl:items-start">
+      <section className="flex flex-col gap-6 rounded-3xl border border-slate-200 bg-slate-50 p-6 shadow-inner">
+        <header>
+          <h2 className="text-2xl font-bold text-sanctuaryBrick">
+            Cargar nuevas imágenes
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            Arrastra tus archivos a la zona inferior o utiliza el botón para
+            seleccionarlos. Puedes organizar el orden antes de subirlos.
+          </p>
+        </header>
+        <div
+          className="flex min-h-[220px] flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-sanctuaryTerracotta/50 bg-white px-6 text-center text-slate-500 transition hover:border-sanctuaryTerracotta"
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+        >
+          <span className="text-sm font-medium uppercase tracking-wide text-sanctuaryTerracotta">
+            Zona de carga
+          </span>
+          <p className="max-w-sm text-sm leading-6">
+            Arrastra y suelta tus imágenes aquí o utiliza el botón inferior.
+            Admitimos hasta 10 archivos con un máximo de 4 MB cada uno.
+          </p>
+          <ImageInput
+            onFilesSelected={(files) =>
+              handleFilesSelected(
+                files,
+                selectedFiles,
+                setSelectedFiles,
+                setError
+              )
+            }
+          />
+        </div>
+        <ImagePreview
+          selectedFiles={selectedFiles}
+          onDelete={(index) => handleDeleteSelected(index, setSelectedFiles)}
+          onMove={handleMoveSelectedImage}
+        />
+        <ErrorMessage error={error} />
+        <div className="flex flex-col gap-4">
+          {(uploading || uploadProgress > 0) && (
+            <ProgressBar progress={uploadProgress} uploading={uploading} />
+          )}
+          <button
+            type="button"
+            onClick={() =>
+              handleUpload(
+                selectedFiles,
+                setUploading,
+                setUploadProgress,
+                setSelectedFiles,
+                fetchImages,
+                setUploadedImages
+              )
+            }
+            disabled={selectedFiles.length === 0 || uploading}
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-green-600 px-5 py-3 text-sm font-semibold uppercase tracking-wide text-white transition hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-gray-400"
+          >
+            <ArrowUpTrayIcon className="h-5 w-5" />
+            Subir imágenes
+          </button>
+        </div>
+      </section>
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg">
+        <header className="flex flex-col gap-2 border-b border-slate-200 pb-4">
+          <h2 className="text-2xl font-bold text-sanctuaryBrick">
+            Biblioteca actual
+          </h2>
+          <p className="text-sm leading-6 text-slate-600">
+            Estas son las imágenes visibles en el carrusel del sitio. Puedes
+            eliminar las que ya no necesites.
+          </p>
+        </header>
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          {uploadedImages.map((image, index) => (
+            <article
+              key={image.id ?? index}
+              className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-slate-50 shadow"
+            >
               <img
                 src={resolveImageSrc(image)}
-                alt={`uploaded-${index}`}
-                className="w-full h-full object-cover rounded"
+                alt={`Imagen carrusel ${index + 1}`}
+                className="h-48 w-full object-cover"
               />
-              <button
-                type="button"
-                aria-label="Eliminar imagen"
-                className="absolute right-2 top-2 rounded-full bg-white/90 p-1 text-red-600 shadow transition hover:bg-red-100"
-                onClick={() => handleDeleteUploaded(image.id, setUploadedImages)}
-              >
-                <TrashIcon className="h-5 w-5" />
-              </button>
-            </div>
-          </div>
-        ))}
-      </div>
+              <div className="absolute right-3 top-3">
+                <button
+                  type="button"
+                  aria-label="Eliminar imagen"
+                  className="rounded-full bg-white/95 p-2 text-red-600 shadow transition hover:bg-red-100"
+                  onClick={() => handleDeleteUploaded(image.id, setUploadedImages)}
+                >
+                  <TrashIcon className="h-5 w-5" />
+                </button>
+              </div>
+            </article>
+          ))}
+          {uploadedImages.length === 0 && (
+            <p className="col-span-full rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-6 py-10 text-center text-sm text-slate-500">
+              No hay imágenes almacenadas actualmente. Sube nuevas fotos para
+              actualizar el carrusel del sitio.
+            </p>
+          )}
+        </div>
+      </section>
     </div>
   );
 };

--- a/src/frontend/components/adminPage/home-carousel/imagePreview.tsx
+++ b/src/frontend/components/adminPage/home-carousel/imagePreview.tsx
@@ -1,48 +1,96 @@
-import React from "react";
+import React, { useEffect, useMemo } from "react";
 import { ChevronLeftIcon, ChevronRightIcon, TrashIcon } from "@components/icons";
 
-const ImagePreview = ({ selectedFiles, onDelete, moveImage }) => (
-  <div className="bg-green-100 mt-4 mx-10 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-    {selectedFiles.map((file, index) => (
-      <div key={index} className="relative h-52">
-        <div className="h-40">
-          <img
-            src={URL.createObjectURL(file)}
-            alt={`preview-${index}`}
-            className="h-full w-full rounded object-cover"
-          />
-          <div className="mt-2 flex items-center justify-between">
-            <button
-              type="button"
-              aria-label="Mover a la izquierda"
-              onClick={() => moveImage(index, -1)}
-              disabled={index === 0}
-              className="rounded-md p-1 text-gray-700 transition hover:bg-gray-200 disabled:cursor-not-allowed disabled:text-gray-400"
-            >
-              <ChevronLeftIcon className="h-5 w-5" />
-            </button>
-            <button
-              type="button"
-              aria-label="Eliminar imagen"
-              onClick={() => onDelete(index)}
-              className="rounded-md p-1 text-red-600 transition hover:bg-red-100"
-            >
-              <TrashIcon className="h-5 w-5" />
-            </button>
-            <button
-              type="button"
-              aria-label="Mover a la derecha"
-              onClick={() => moveImage(index, 1)}
-              disabled={index === selectedFiles.length - 1}
-              className="rounded-md p-1 text-gray-700 transition hover:bg-gray-200 disabled:cursor-not-allowed disabled:text-gray-400"
-            >
-              <ChevronRightIcon className="h-5 w-5" />
-            </button>
+type ImagePreviewProps = {
+  selectedFiles: File[];
+  onDelete: (index: number) => void;
+  onMove?: (index: number, direction: number) => void;
+  className?: string;
+};
+
+const ImagePreview = ({ selectedFiles, onDelete, onMove, className }: ImagePreviewProps) => {
+  const previews = useMemo(
+    () =>
+      selectedFiles.map((file) => ({
+        key: `${file.name}-${file.lastModified}`,
+        url: URL.createObjectURL(file),
+      })),
+    [selectedFiles]
+  );
+
+  useEffect(() => {
+    return () => {
+      previews.forEach((preview) => URL.revokeObjectURL(preview.url));
+    };
+  }, [previews]);
+
+  if (previews.length === 0) {
+    return (
+      <p className="rounded-xl border border-dashed border-slate-300 bg-white/50 px-4 py-6 text-center text-sm text-slate-500">
+        Aún no has seleccionado imágenes. Arrastra archivos sobre la zona superior o usa el botón “Seleccionar imágenes”.
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className={`grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-2 2xl:grid-cols-3 ${
+        className ?? ""
+      }`}
+    >
+      {previews.map((preview, index) => {
+        const file = selectedFiles[index];
+        return (
+          <div
+            key={preview.key}
+            className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
+          >
+            <img
+              src={preview.url}
+              alt={`preview-${index}`}
+              className="h-48 w-full object-cover"
+            />
+            <div className="flex items-center justify-between gap-2 border-t border-slate-200 bg-slate-50 px-3 py-2 text-slate-600">
+              {onMove ? (
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    aria-label="Mover a la izquierda"
+                    onClick={() => onMove(index, -1)}
+                    disabled={index === 0}
+                    className="rounded-full p-1 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:text-slate-400"
+                  >
+                    <ChevronLeftIcon className="h-5 w-5" />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Mover a la derecha"
+                    onClick={() => onMove(index, 1)}
+                    disabled={index === selectedFiles.length - 1}
+                    className="rounded-full p-1 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:text-slate-400"
+                  >
+                    <ChevronRightIcon className="h-5 w-5" />
+                  </button>
+                </div>
+              ) : (
+                <span className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                  Vista previa
+                </span>
+              )}
+              <button
+                type="button"
+                aria-label="Eliminar imagen"
+                onClick={() => onDelete(index)}
+                className="rounded-full p-1 text-red-600 transition hover:bg-red-100"
+              >
+                <TrashIcon className="h-5 w-5" />
+              </button>
+            </div>
           </div>
-        </div>
-      </div>
-    ))}
-  </div>
-);
+        );
+      })}
+    </div>
+  );
+};
 
 export default ImagePreview;

--- a/src/frontend/components/adminPage/home-carousel/uploadImageHandler.tsx
+++ b/src/frontend/components/adminPage/home-carousel/uploadImageHandler.tsx
@@ -28,12 +28,12 @@ export const fetchImages = async (setUploadedImages: (images: CarouselItem[]) =>
 };
 
 export const handleFilesSelected = (
-  files: FileList,
+  files: FileList | File[],
   selectedFiles: File[],
-  setSelectedFiles: (updater: (prevFiles: File[]) => File[]) => void,
+  setSelectedFiles: (files: File[] | ((prevFiles: File[]) => File[])) => void,
   setError: (message: string) => void
 ) => {
-  const newFiles = Array.from(files);
+  const newFiles = Array.isArray(files) ? files : Array.from(files ?? []);
   const oversizedFiles = newFiles.filter((file) => file.size > MAX_IMAGE_SIZE);
 
   if (oversizedFiles.length > 0) {


### PR DESCRIPTION
## Summary
- Broaden the admin shell with a wider grid layout, sans-serif typography, and a dedicated home shortcut for easier navigation
- Rework the carousel manager into side-by-side upload and library panes with drag & drop support, reorderable previews, and safer file handling
- Replace modal flows for activities and workers with desktop-first panels that pair upload forms, live previews, and database grids for quick edits

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d055135280832c9e23d5dee957ea31