### PR TITLE
Enhance home page with lateral transitions

### DIFF
--- a/src/frontend/app/page.tsx
+++ b/src/frontend/app/page.tsx
@@ -11,7 +11,7 @@ import "../i18next.config";
 
 export default function Home() {
   const { t, i18n } = useTranslation();
-  const [ref, isVisible] = useIntersectionObserver({ threshold: 0.2 });
+  const [introRef, isIntroVisible] = useIntersectionObserver<HTMLDivElement>({ threshold: 0.2 });
 
   if (!i18n.isInitialized) {
     return <Loading />;
@@ -21,19 +21,37 @@ export default function Home() {
     <PageShell>
       <HomeHero />
       <section className="bg-sanctuaryLinen py-12">
-        <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 px-6 text-center md:items-start md:text-left">
-          <h2 className="text-3xl font-display text-sanctuaryBrick sm:text-4xl">{t("welcome")}</h2>
+        <div
+          ref={introRef}
+          className={`mx-auto flex max-w-4xl transform-gpu flex-col items-center gap-6 px-6 text-center transition-all duration-700 ease-out md:items-start md:text-left ${
+            isIntroVisible
+              ? "translate-x-0 opacity-100"
+              : "-translate-x-6 opacity-0 md:-translate-x-12"
+          }`}
+        >
+          <h2
+            className={`text-3xl font-display text-sanctuaryBrick transition-all duration-700 ease-out sm:text-4xl ${
+              isIntroVisible ? "translate-x-0" : "translate-x-4 md:translate-x-8"
+            }`}
+          >
+            {t("welcome")}
+          </h2>
           <p
-            ref={ref}
             className={`font-body text-base text-sanctuaryDeep transition-all duration-700 ease-out md:text-lg ${
-              isVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+              isIntroVisible
+                ? "translate-x-0 opacity-100 delay-150"
+                : "translate-x-6 opacity-0 delay-0 md:translate-x-10"
             }`}
           >
             {t("sections.about.subtitle")}
           </p>
           <Link
             href="/nosotros"
-            className="rounded-full bg-sanctuaryBrick px-6 py-3 font-display text-sm uppercase tracking-widest text-sanctuaryLinen shadow-md transition hover:bg-sanctuaryTerracotta"
+            className={`rounded-full bg-sanctuaryBrick px-6 py-3 font-display text-sm uppercase tracking-widest text-sanctuaryLinen shadow-md transition-all duration-700 ease-out hover:bg-sanctuaryTerracotta ${
+              isIntroVisible
+                ? "translate-x-0 opacity-100 delay-200"
+                : "translate-x-8 opacity-0 delay-0 md:translate-x-12"
+            }`}
           >
             {t("navigation.us")}
           </Link>

--- a/src/frontend/components/homeHero.tsx
+++ b/src/frontend/components/homeHero.tsx
@@ -44,37 +44,60 @@ const HomeHero = () => {
 
   return (
     <section className="relative mt-[-80px] flex h-[60vh] min-h-[320px] items-center justify-center overflow-hidden bg-black text-white md:mt-[-96px] md:h-[70vh]">
-      {slides.map((slide, index) => (
-        <div
-          key={slide.imageUrl}
-          className={`absolute inset-0 transition-opacity duration-1000 ease-out ${
-            index === current ? "opacity-100" : "opacity-0"
-          }`}
-        >
-          <img
-            src={slide.imageUrl}
-            alt={`${t("hero.slides." + index + ".title")}`}
-            className="h-full w-full object-cover"
-          />
-          <div className="absolute inset-0 bg-black/50" />
-          <div className="absolute inset-0 flex flex-col items-center justify-center px-6 text-center md:px-12">
-            <h1
-              className={`text-3xl font-display tracking-wide sm:text-4xl md:text-5xl ${
-                index === current ? "translate-y-0 opacity-100" : "translate-y-6 opacity-0"
-              } transition-all duration-700 ease-out`}
-            >
-              {t(slide.titleKey)}
-            </h1>
-            <p
-              className={`mt-4 max-w-2xl text-sm font-body sm:text-base md:text-lg ${
-                index === current ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
-              } transition-all duration-700 ease-out delay-150`}
-            >
-              {t(slide.descriptionKey)}
-            </p>
+      {slides.map((slide, index) => {
+        const isActive = index === current;
+        const isEven = index % 2 === 0;
+        const textOffsetClass = isEven
+          ? "-translate-x-16 md:-translate-x-24"
+          : "translate-x-16 md:translate-x-24";
+        const imageOffsetClass = isEven
+          ? "translate-x-6 scale-105"
+          : "-translate-x-6 scale-105";
+
+        return (
+          <div
+            key={slide.imageUrl}
+            className={`absolute inset-0 transform-gpu transition-opacity duration-1000 ease-out ${
+              isActive ? "opacity-100" : "opacity-0"
+            }`}
+          >
+            <img
+              src={slide.imageUrl}
+              alt={`${t("hero.slides." + index + ".title")}`}
+              className={`h-full w-full object-cover transition-transform duration-[2000ms] ease-out transform-gpu ${
+                isActive ? "translate-x-0 scale-100" : imageOffsetClass
+              }`}
+            />
+            <div className="absolute inset-0 bg-black/50" />
+            <div className="absolute inset-0 flex flex-col items-center justify-center px-6 text-center md:px-12">
+              <div
+                className={`flex max-w-2xl flex-col items-center text-center transition-all duration-700 ease-out transform-gpu ${
+                  isActive ? "translate-x-0 opacity-100" : `${textOffsetClass} opacity-0`
+                }`}
+              >
+                <h1
+                  className={`text-3xl font-display tracking-wide transition-all duration-700 ease-out sm:text-4xl md:text-5xl ${
+                    isActive
+                      ? "translate-x-0 opacity-100 delay-150"
+                      : `${isEven ? "-translate-x-6" : "translate-x-6"} opacity-0 delay-0`
+                  }`}
+                >
+                  {t(slide.titleKey)}
+                </h1>
+                <p
+                  className={`mt-4 text-sm font-body transition-all duration-700 ease-out sm:text-base md:text-lg ${
+                    isActive
+                      ? "translate-x-0 opacity-100 delay-300"
+                      : `${isEven ? "-translate-x-4" : "translate-x-4"} opacity-0 delay-0`
+                  }`}
+                >
+                  {t(slide.descriptionKey)}
+                </p>
+              </div>
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
       <div className="absolute bottom-6 flex gap-2">
         {slides.map((slide, index) => (
           <button


### PR DESCRIPTION
## Summary
- add lateral reveal animation to the home intro section for a subtle side-entry experience
- update the hero carousel to alternate horizontal slide transitions for imagery and copy

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d061389ea8832ca7cce244e4845229