### PR TITLE
Sanitize inputs and refresh footer styling

### DIFF
--- a/src/frontend/app/donations/page.tsx
+++ b/src/frontend/app/donations/page.tsx
@@ -2,6 +2,10 @@
 import { useState, useEffect } from "react";
 import { loadStripe } from "@stripe/stripe-js";
 import PageShell from "@components/pageShell";
+import {
+  sanitizeNumericInput,
+  sanitizeSelectInput,
+} from "@frontend/utils/sanitize";
 
 const stripePromise = loadStripe(
   process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
@@ -42,7 +46,8 @@ const DonateForm = () => {
   };
 
   const handleAmountChange = (e) => {
-    const value = Number(e.target.value);
+    const sanitizedValue = sanitizeNumericInput(e.target.value);
+    const value = Number(sanitizedValue);
     if (value < 0) {
       setAmount(0);
     } else {
@@ -97,7 +102,11 @@ const DonateForm = () => {
           id="paymentMethod"
           name="paymentMethod"
           value={paymentMethod}
-          onChange={(e) => setPaymentMethod(e.target.value)}
+          onChange={(e) =>
+            setPaymentMethod(
+              sanitizeSelectInput(e.target.value, ["1", "stripe", "tropipay"], "1")
+            )
+          }
           className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:border-sanctuaryTerracotta focus:outline-none focus:ring-1 focus:ring-sanctuaryTerracotta"
         >
           <option value="1" disabled>

--- a/src/frontend/app/secret/page.tsx
+++ b/src/frontend/app/secret/page.tsx
@@ -5,6 +5,7 @@ import {
   grantAdminSessionAccess,
   grantAdminTemporaryAccess,
 } from "@frontend/utils/adminAccess";
+import { sanitizeTextInput } from "@frontend/utils/sanitize";
 import {
   ArrowRightOnRectangleIcon,
   LockClosedIcon,
@@ -75,7 +76,7 @@ const AdminLogin = () => {
                 <UserIcon className="absolute left-3 h-5 w-5 text-slate-400" />
                 <input
                   id="userName"
-                  onChange={(e) => setUser(e.target.value)}
+                  onChange={(e) => setUser(sanitizeTextInput(e.target.value))}
                   type="text"
                   placeholder="Usuario"
                   className="w-full rounded-md border border-slate-300 bg-slate-100 py-3 pl-11 pr-3 text-sm text-slate-700 transition focus:border-sanctuaryTerracotta focus:outline-none focus:ring-1 focus:ring-sanctuaryTerracotta"
@@ -85,7 +86,7 @@ const AdminLogin = () => {
                 <LockClosedIcon className="absolute left-3 h-5 w-5 text-slate-400" />
                 <input
                   id="pass"
-                  onChange={(e) => setPass(e.target.value)}
+                  onChange={(e) => setPass(sanitizeTextInput(e.target.value))}
                   type="password"
                   placeholder="Contraseña"
                   className="w-full rounded-md border border-slate-300 bg-slate-100 py-3 pl-11 pr-3 text-sm text-slate-700 transition focus:border-sanctuaryTerracotta focus:outline-none focus:ring-1 focus:ring-sanctuaryTerracotta"

--- a/src/frontend/components/footerApp.tsx
+++ b/src/frontend/components/footerApp.tsx
@@ -16,17 +16,104 @@ const FooterApp = ({ showContact = true }: FooterAppProps) => {
   }
 
   return (
-    <footer className="bg-sanctuaryDeep text-sanctuaryLinen">
-      {showContact && <ContactUs />}
-      <p className="flex flex-col justify-center gap-1 px-4 py-3 text-center font-display sm:flex-row">
-        <span>
-          © 2024 Iglesia de San Bautista de{" "}
-          <Link className="cursor-default text-sanctuaryGold" href="/secret">
-            Remedios.
-          </Link>
-        </span>
-        <span>{t("Todos los derechos reservados.")}</span>
-      </p>
+    <footer className="relative overflow-hidden bg-gradient-to-br from-sanctuaryDeep via-slate-900 to-[#04060d] text-sanctuaryLinen">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.16),transparent_60%)]" />
+      <div className="pointer-events-none absolute -top-24 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-sanctuaryGold/10 blur-3xl" />
+      <div className="relative">
+        {showContact && (
+          <div className="allow-text-selection border-b border-white/10 bg-sanctuaryCream/10 backdrop-blur-sm">
+            <ContactUs />
+          </div>
+        )}
+        <div className="mx-auto flex max-w-6xl flex-col gap-12 px-6 py-12 lg:px-8 lg:py-16">
+          <div className="grid gap-10 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)]">
+            <div className="space-y-5">
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-sanctuaryGold/80">
+                Comunidad viva
+              </p>
+              <h2 className="text-3xl font-display text-white md:text-4xl">
+                Iglesia de San Bautista de Remedios
+              </h2>
+              <p className="allow-text-selection text-sm leading-6 text-slate-300">
+                Celebramos la fe con música, servicio y esperanza. Únete a nuestras
+                actividades, participa en los ministerios y comparte la experiencia de
+                una iglesia cercana y comprometida.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  href="/donations"
+                  className="inline-flex items-center justify-center rounded-full border border-white/20 px-5 py-2 text-sm font-semibold text-white transition hover:border-sanctuaryGold hover:bg-sanctuaryGold/10"
+                >
+                  Realizar una donación
+                </Link>
+                <Link
+                  href="/contacto"
+                  className="inline-flex items-center justify-center rounded-full bg-sanctuaryGold/20 px-5 py-2 text-sm font-semibold text-sanctuaryGold transition hover:bg-sanctuaryGold/30"
+                >
+                  Planificar una visita
+                </Link>
+              </div>
+            </div>
+            <div>
+              <h3 className="text-xs font-semibold uppercase tracking-[0.35em] text-sanctuaryGold/80">
+                Explora
+              </h3>
+              <ul className="mt-4 space-y-3 text-sm text-slate-200">
+                <li>
+                  <Link className="transition hover:text-sanctuaryGold" href="/">
+                    Inicio
+                  </Link>
+                </li>
+                <li>
+                  <Link className="transition hover:text-sanctuaryGold" href="/nosotros">
+                    Nosotros
+                  </Link>
+                </li>
+                <li>
+                  <Link className="transition hover:text-sanctuaryGold" href="/servicios">
+                    Servicios
+                  </Link>
+                </li>
+                <li>
+                  <Link className="transition hover:text-sanctuaryGold" href="/donations">
+                    Donaciones
+                  </Link>
+                </li>
+              </ul>
+            </div>
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-2xl shadow-black/25 backdrop-blur">
+              <h3 className="text-xs font-semibold uppercase tracking-[0.35em] text-sanctuaryGold/90">
+                Próximo servicio
+              </h3>
+              <p className="mt-4 text-lg font-display text-white">Domingos · 10:30 a.m.</p>
+              <p className="allow-text-selection mt-3 text-sm leading-6 text-slate-200">
+                Te esperamos en Remedios para compartir juntos un tiempo de adoración,
+                reflexión y comunidad.
+              </p>
+              <Link
+                href="/contacto"
+                className="mt-5 inline-flex items-center justify-center rounded-full bg-sanctuaryTerracotta px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow transition hover:bg-sanctuaryBrick"
+              >
+                Cómo llegar
+              </Link>
+            </div>
+          </div>
+          <div className="flex flex-col gap-4 border-t border-white/10 pt-8 text-xs text-slate-400 md:flex-row md:items-center md:justify-between">
+            <p className="allow-text-selection text-center md:text-left">
+              © 2024 Iglesia de San Bautista de{" "}
+              <Link className="cursor-default text-sanctuaryGold" href="/secret">
+                Remedios.
+              </Link>{" "}
+              {t("Todos los derechos reservados.")}
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-4 uppercase tracking-[0.35em] text-sanctuaryGold/60">
+              <span>Fe</span>
+              <span>Comunidad</span>
+              <span>Servicio</span>
+            </div>
+          </div>
+        </div>
+      </div>
     </footer>
   );
 };

--- a/src/frontend/styles/globals.css
+++ b/src/frontend/styles/globals.css
@@ -25,6 +25,22 @@ html {
   scroll-behavior: smooth;
 }
 
+body {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+
+input,
+textarea,
+select,
+.allow-text-selection,
+[contenteditable="true"] {
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  user-select: text;
+}
+
 ::-webkit-scrollbar-track {
   background: transparent;
   border-radius: 4px;

--- a/src/frontend/utils/sanitize.ts
+++ b/src/frontend/utils/sanitize.ts
@@ -1,0 +1,35 @@
+const STRIP_SCRIPTS = /<script[^>]*>[\s\S]*?<\/script>/gi;
+const STRIP_TAGS = /<[^>]+>/g;
+const CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]+/g;
+
+export const sanitizeTextInput = (value: string): string => {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value
+    .replace(STRIP_SCRIPTS, "")
+    .replace(STRIP_TAGS, "")
+    .replace(/javascript:/gi, "")
+    .replace(/data:/gi, "")
+    .replace(CONTROL_CHARS, "");
+};
+
+export const sanitizeNumericInput = (value: string): string => {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.replace(/[^0-9]/g, "");
+};
+
+export const sanitizeSelectInput = (
+  value: string,
+  allowedValues: readonly string[],
+  fallback: string
+): string => {
+  if (allowedValues.includes(value)) {
+    return value;
+  }
+  return allowedValues.includes(fallback) ? fallback : allowedValues[0];
+};


### PR DESCRIPTION
## Summary
- add shared sanitization helpers and apply them across admin and donation inputs to strip unsafe content
- disable text selection globally while keeping form fields selectable for usability
- redesign the footer with a modern gradient layout, expanded navigation, and refreshed calls to action

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0651ed7a4832ca21f72ac6e591ffd